### PR TITLE
Feat/cognito error handler

### DIFF
--- a/src/modules/auth/application/dto/create-user.dto.ts
+++ b/src/modules/auth/application/dto/create-user.dto.ts
@@ -1,7 +1,7 @@
-import { IsString, Matches } from 'class-validator';
+import { IsEmail, Matches } from 'class-validator';
 
 export class CreateUserDto {
-  @IsString()
+  @IsEmail()
   username: string;
 
   @Matches(

--- a/src/modules/auth/application/enum/cognito.enum.ts
+++ b/src/modules/auth/application/enum/cognito.enum.ts
@@ -1,5 +1,0 @@
-export enum COGNITO_RESPONSE {
-  INVALID_PASSWORD = 'Please enter a valid password',
-  FAILED_LOGIN = 'Failed to login',
-  FAILED_REGISTER = 'Failed to register, please try again',
-}

--- a/src/modules/auth/application/exceptions/cognito-errors.exceptions.ts
+++ b/src/modules/auth/application/exceptions/cognito-errors.exceptions.ts
@@ -1,0 +1,47 @@
+import {
+  BadRequestException,
+  InternalServerErrorException,
+  NotFoundException,
+  RequestTimeoutException,
+  ServiceUnavailableException,
+  UnauthorizedException,
+} from '@nestjs/common';
+
+import { COGNITO_EXCEPTION, COGNITO_RESPONSE } from './cognito.enum';
+import { CognitoError } from './cognito.error';
+
+export function exceptionsCognitoErrors(
+  error: CognitoError,
+  path: string,
+): void {
+  switch (error.code) {
+    case COGNITO_EXCEPTION.CODE_DELIVERY_FAILURE:
+      throw new BadRequestException(COGNITO_RESPONSE.CODE_DELIVERY_FAILURE);
+    case COGNITO_EXCEPTION.INVALID_PARAMETER:
+      throw new BadRequestException(COGNITO_RESPONSE.INVALID_PARAMETER);
+    case COGNITO_EXCEPTION.INVALID_PASSWORD:
+      throw new BadRequestException(COGNITO_RESPONSE.INVALID_PASSWORD);
+    case COGNITO_EXCEPTION.INTERNAL_ERROR:
+      throw new InternalServerErrorException(COGNITO_RESPONSE.INTERNAL_ERROR);
+    case COGNITO_EXCEPTION.NOT_AUTHORIZED:
+      throw new UnauthorizedException(COGNITO_RESPONSE.NOT_AUTHORIZED);
+    case COGNITO_EXCEPTION.REQUEST_EXPIRED:
+      throw new RequestTimeoutException(COGNITO_RESPONSE.REQUEST_EXPIRED);
+    case COGNITO_EXCEPTION.SERVICE_UNAVAILABLE:
+      throw new ServiceUnavailableException(
+        COGNITO_RESPONSE.SERVICE_UNAVAILABLE,
+      );
+    case COGNITO_EXCEPTION.TOO_MANY_REQUEST:
+      throw new BadRequestException(COGNITO_RESPONSE.TOO_MANY_REQUEST);
+    case COGNITO_EXCEPTION.USERNAME_EXIST:
+      throw new BadRequestException(COGNITO_RESPONSE.USERNAME_EXIST);
+    case COGNITO_EXCEPTION.USER_NOT_CONFIRMED:
+      throw new NotFoundException(COGNITO_RESPONSE.USER_NOT_CONFIRMED);
+    default:
+      if (path === 'login') {
+        throw new BadRequestException(COGNITO_RESPONSE.FAILED_LOGIN);
+      } else if (path === 'register') {
+        throw new BadRequestException(COGNITO_RESPONSE.FAILED_REGISTER);
+      }
+  }
+}

--- a/src/modules/auth/application/exceptions/cognito.enum.ts
+++ b/src/modules/auth/application/exceptions/cognito.enum.ts
@@ -1,0 +1,28 @@
+export enum COGNITO_RESPONSE {
+  CODE_DELIVERY_FAILURE = 'The verification code was not delivered correctly',
+  FAILED_LOGIN = 'Failed to login',
+  FAILED_REGISTER = 'Failed to register, please try again',
+  INTERNAL_ERROR = 'Amazon Cognito internal error, please try again',
+  INVALID_PARAMETER = 'One of the parameters entered is invalid',
+  INVALID_PASSWORD = 'Please enter a valid password',
+  NOT_AUTHORIZED = 'Invalid username or password',
+  REQUEST_EXPIRED = 'The request has expired, please try again',
+  SERVICE_UNAVAILABLE = 'Temporary failure of the server, please try again',
+  TOO_MANY_REQUEST = "Please don't submit the request too many times",
+  USERNAME_EXIST = 'The email is already registered',
+  USER_NOT_CONFIRMED = 'The user is not confirmed',
+  USER_NOT_FOUND_OR_EXIST = 'The user is not found or not exist',
+}
+
+export enum COGNITO_EXCEPTION {
+  CODE_DELIVERY_FAILURE = 'CodeDeliveryFailureException',
+  INVALID_PARAMETER = 'InvalidParameterException',
+  INVALID_PASSWORD = 'InvalidPasswordException',
+  INTERNAL_ERROR = 'InternalErrorException',
+  NOT_AUTHORIZED = 'NotAuthorizedException',
+  REQUEST_EXPIRED = 'RequestExpired',
+  SERVICE_UNAVAILABLE = 'ServiceUnavailable',
+  TOO_MANY_REQUEST = 'TooManyRequestsException',
+  USERNAME_EXIST = 'UsernameExistsException',
+  USER_NOT_CONFIRMED = 'UserNotConfirmedException',
+}

--- a/src/modules/auth/application/exceptions/cognito.error.ts
+++ b/src/modules/auth/application/exceptions/cognito.error.ts
@@ -1,0 +1,6 @@
+export class CognitoError extends Error {
+  code: string;
+  constructor() {
+    super();
+  }
+}

--- a/src/modules/auth/application/service/auth.service.ts
+++ b/src/modules/auth/application/service/auth.service.ts
@@ -1,8 +1,9 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, NotFoundException } from '@nestjs/common';
 
 import { CreateUserDto } from '../dto/create-user.dto';
 import { LoginUserDto } from '../dto/login-user.dto';
-import { COGNITO_RESPONSE } from '../enum/cognito.enum';
+import { exceptionsCognitoErrors } from '../exceptions/cognito-errors.exceptions';
+import { COGNITO_RESPONSE } from '../exceptions/cognito.enum';
 import { AuthMapper } from '../mapper/user.mapper';
 import {
   COGNITO_SERVICE,
@@ -26,7 +27,7 @@ export class AuthService {
     try {
       return await this.cognitoService.loginAccount(username, password);
     } catch (error) {
-      throw new Error(COGNITO_RESPONSE.FAILED_LOGIN);
+      exceptionsCognitoErrors(error, 'login');
     }
   }
 
@@ -43,14 +44,14 @@ export class AuthService {
 
       return registeredUser;
     } catch (error) {
-      console.log(error);
+      exceptionsCognitoErrors(error, 'register');
     }
   }
 
   async findOneByexternalId(id: string) {
     const userResponse = await this.userRepository.findOneByexternalId(id);
     if (!userResponse) {
-      throw new Error(COGNITO_RESPONSE.FAILED_LOGIN);
+      throw new NotFoundException(COGNITO_RESPONSE.USER_NOT_FOUND_OR_EXIST);
     }
 
     return userResponse;

--- a/src/modules/auth/infrastructure/jwt/jwt.strategy.ts
+++ b/src/modules/auth/infrastructure/jwt/jwt.strategy.ts
@@ -3,7 +3,7 @@ import { PassportStrategy } from '@nestjs/passport';
 import { passportJwtSecret } from 'jwks-rsa';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 
-import { COGNITO_RESPONSE } from '../../application/enum/cognito.enum';
+import { COGNITO_RESPONSE } from '../../application/exceptions/cognito.enum';
 import { AuthService } from '../../application/service/auth.service';
 
 @Injectable()

--- a/src/modules/parameter/application/dto/update-param.dto.ts
+++ b/src/modules/parameter/application/dto/update-param.dto.ts
@@ -1,5 +1,5 @@
 import { PartialType } from '@nestjs/mapped-types';
-import { IsNotEmpty, IsNumber, IsString } from 'class-validator';
+import { IsNotEmpty, IsString } from 'class-validator';
 
 import { CreateParamDto } from './create-param.dto';
 


### PR DESCRIPTION
# Summary

- Add `COGNITO_EXCEPTION` and `COGNITO_RESPONSE` enums
- Add cognito handler error and `CognitoError` class
- Add Cognito handle error In `auth.service`
- Fix import and create user to

# Details

- Cognito error handling is dynamic for `login` and `register` endpoints
- The `CognitoError` class is necessary to be able to bring the property code