### PR TITLE
Delete methods by invocation id

### DIFF
--- a/src/modules/invocation/application/exceptions/invocation-response.enum.dto.ts
+++ b/src/modules/invocation/application/exceptions/invocation-response.enum.dto.ts
@@ -9,4 +9,6 @@ export enum INVOCATION_RESPONSE {
   INVOCATION_FOLDER_NOT_EXISTS = 'Folder not exists or its not yours',
   INVOCATION_FAIL_GENERATE_METHODS_WITH_CONTRACT_ID = 'It was not possible to generate new methods with the assigned contract id.',
   INVOCATION_FAIL_RUN_INVOCATION = 'It was not possible to run the invocation',
+  INVOCATION_FAIL_WITH_NEW_CONTRACT_AND_NEW_METHOD = 'You cannot set a new method and new contract at the same time',
+  INVOCATION_FAIL_SELECTING_METHOD_WITHOUT_CONTRACT = 'You cannot choose a method without having a loaded contract',
 }

--- a/src/modules/invocation/application/exceptions/invocation.exceptions.ts
+++ b/src/modules/invocation/application/exceptions/invocation.exceptions.ts
@@ -1,0 +1,31 @@
+import { NotFoundException } from '@nestjs/common';
+
+import { Invocation } from '../../domain/invocation.domain';
+import { UpdateInvocationDto } from '../dto/update-invocation.dto';
+import { INVOCATION_RESPONSE } from './invocation-response.enum.dto';
+
+export class InvocationException {
+  validateInvocation(
+    invocation: Invocation,
+    updateInvocationDto: UpdateInvocationDto,
+  ) {
+    if (!invocation) {
+      throw new NotFoundException(
+        INVOCATION_RESPONSE.Invocation_NOT_FOUND_BY_USER_AND_ID,
+      );
+    }
+    if (updateInvocationDto.selectedMethodId && !invocation.contractId) {
+      throw new NotFoundException(
+        INVOCATION_RESPONSE.INVOCATION_FAIL_SELECTING_METHOD_WITHOUT_CONTRACT,
+      );
+    }
+    if (
+      updateInvocationDto.selectedMethodId &&
+      updateInvocationDto.contractId
+    ) {
+      throw new NotFoundException(
+        INVOCATION_RESPONSE.INVOCATION_FAIL_WITH_NEW_CONTRACT_AND_NEW_METHOD,
+      );
+    }
+  }
+}

--- a/src/modules/invocation/application/service/invocation.service.ts
+++ b/src/modules/invocation/application/service/invocation.service.ts
@@ -167,7 +167,7 @@ export class InvocationService {
           await this.contractService.generateMethodsFromContractId(
             updateInvocationDto.contractId,
           );
-        await this.methodService.deleteAll(user);
+        await this.methodService.deleteAllByInvocationId(user, invocation.id);
 
         const methodsMapped = generatedMethods.map((method) => {
           const methodValues: IMethodValues = {

--- a/src/modules/invocation/invocation.module.ts
+++ b/src/modules/invocation/invocation.module.ts
@@ -5,6 +5,7 @@ import { CommonModule } from '@/common/common.module';
 
 import { FolderModule } from '../folder/folder.module';
 import { MethodModule } from '../method/method.module';
+import { InvocationException } from './application/exceptions/invocation.exceptions';
 import { InvocationMapper } from './application/mapper/invocation.mapper';
 import { INVOCATION_REPOSITORY } from './application/repository/invocation.repository';
 import { InvocationService } from './application/service/invocation.service';
@@ -21,6 +22,7 @@ import { InvocationController } from './interface/invocation.controller';
   ],
   controllers: [InvocationController],
   providers: [
+    InvocationException,
     InvocationService,
     InvocationMapper,
     {

--- a/src/modules/method/application/repository/method.interface.repository.ts
+++ b/src/modules/method/application/repository/method.interface.repository.ts
@@ -7,6 +7,10 @@ import { Method } from '../../domain/method.domain';
 export interface IMethodRepository extends IBaseRepository<Method> {
   saveAll(methods: Method[]): Promise<Method[]>;
   findAll(userId: string): Promise<Method[]>;
+  findAllByInvocationId(
+    invocationId: string,
+    userId: string,
+  ): Promise<Method[]>;
   findOneByIds(id: string, userId: string): Promise<Method>;
   update(param: Method): Promise<Method>;
   delete(id: string): Promise<boolean>;

--- a/src/modules/method/application/service/method.service.ts
+++ b/src/modules/method/application/service/method.service.ts
@@ -177,4 +177,17 @@ export class MethodService {
       throw new NotFoundException(METHOD_RESPONSE.METHODS_NOT_DELETED);
     }
   }
+
+  async deleteAllByInvocationId(user: IUserResponse, invocationId: string) {
+    const methods = await this.methodRepository.findAllByInvocationId(
+      invocationId,
+      user.id,
+    );
+    if (methods) {
+      await this.methodRepository.deleteAll(methods.map((method) => method.id));
+      return true;
+    } else {
+      throw new NotFoundException(METHOD_RESPONSE.METHODS_NOT_DELETED);
+    }
+  }
 }

--- a/src/modules/method/application/service/method.service.ts
+++ b/src/modules/method/application/service/method.service.ts
@@ -14,6 +14,7 @@ import {
 } from '@/modules/invocation/application/repository/invocation.repository';
 import { IUpdateInvocationValues } from '@/modules/invocation/application/service/invocation.service';
 
+import { Method } from '../../domain/method.domain';
 import { CreateMethodDto } from '../dto/create-method.dto';
 import { MethodResponseDto } from '../dto/method-response.dto';
 import { UpdateMethodDto } from '../dto/update-method.dto';
@@ -168,26 +169,11 @@ export class MethodService {
     return this.methodRepository.delete(id);
   }
 
-  async deleteAll(user: IUserResponse): Promise<boolean> {
-    const methods = await this.methodRepository.findAll(user.id);
-    if (methods) {
-      await this.methodRepository.deleteAll(methods.map((method) => method.id));
-      return true;
-    } else {
+  async deleteAll(methods: Method[]): Promise<boolean> {
+    if (!methods) {
       throw new NotFoundException(METHOD_RESPONSE.METHODS_NOT_DELETED);
     }
-  }
-
-  async deleteAllByInvocationId(user: IUserResponse, invocationId: string) {
-    const methods = await this.methodRepository.findAllByInvocationId(
-      invocationId,
-      user.id,
-    );
-    if (methods) {
-      await this.methodRepository.deleteAll(methods.map((method) => method.id));
-      return true;
-    } else {
-      throw new NotFoundException(METHOD_RESPONSE.METHODS_NOT_DELETED);
-    }
+    await this.methodRepository.deleteAll(methods.map((method) => method.id));
+    return true;
   }
 }

--- a/src/modules/method/infrastructure/persistence/method.typeorm.repository.ts
+++ b/src/modules/method/infrastructure/persistence/method.typeorm.repository.ts
@@ -30,6 +30,18 @@ export class MethodRepository implements IMethodRepository {
     });
   }
 
+  async findAllByInvocationId(
+    invocationId: string,
+    userId: string,
+  ): Promise<Method[]> {
+    return await this.repository.find({
+      where: {
+        invocationId,
+        userId,
+      },
+    });
+  }
+
   async findOne(id: string): Promise<Method> {
     return await this.repository.findOne({
       where: {


### PR DESCRIPTION
### Summary
We are currently deleting all user methods, we want to remove only the ones related to the invocation that is being edited 

### Changes
- Add new `deleteAllByInvocationId` to the method service
- Add new `findAllByInvocationId` function