### PR TITLE
add exception in run invocation method

### DIFF
--- a/src/modules/invocation/application/exceptions/invocation-response.enum.dto.ts
+++ b/src/modules/invocation/application/exceptions/invocation-response.enum.dto.ts
@@ -11,4 +11,5 @@ export enum INVOCATION_RESPONSE {
   INVOCATION_FAIL_RUN_INVOCATION = 'It was not possible to run the invocation',
   INVOCATION_FAIL_WITH_NEW_CONTRACT_AND_NEW_METHOD = 'You cannot set a new method and new contract at the same time',
   INVOCATION_FAIL_SELECTING_METHOD_WITHOUT_CONTRACT = 'You cannot choose a method without having a loaded contract',
+  INVOCATION_FAILED_TO_RUN_WITHOUT_KEYS_OR_SELECTED_METHOD = 'It was not possible to run the invocation. Check if you have selected method or keys',
 }

--- a/src/modules/invocation/application/exceptions/invocation-response.enum.dto.ts
+++ b/src/modules/invocation/application/exceptions/invocation-response.enum.dto.ts
@@ -11,5 +11,5 @@ export enum INVOCATION_RESPONSE {
   INVOCATION_FAIL_RUN_INVOCATION = 'It was not possible to run the invocation',
   INVOCATION_FAIL_WITH_NEW_CONTRACT_AND_NEW_METHOD = 'You cannot set a new method and new contract at the same time',
   INVOCATION_FAIL_SELECTING_METHOD_WITHOUT_CONTRACT = 'You cannot choose a method without having a loaded contract',
-  INVOCATION_FAILED_TO_RUN_WITHOUT_KEYS_OR_SELECTED_METHOD = 'It was not possible to run the invocation. Check if you have selected method or keys',
+  INVOCATION_FAILED_TO_RUN_WITHOUT_KEYS_OR_SELECTED_METHOD = 'It was not possible to run the invocation. Check if you have selected a method and authentication keys',
 }

--- a/src/modules/invocation/application/service/invocation.service.ts
+++ b/src/modules/invocation/application/service/invocation.service.ts
@@ -71,6 +71,16 @@ export class InvocationService {
 
   async runInvocation(user: IUserResponse, id: string) {
     const invocation = await this.findOneByIds(user, id);
+
+    if (
+      !invocation.secretKey ||
+      !invocation.publicKey ||
+      !invocation.selectedMethod
+    ) {
+      throw new NotFoundException(
+        INVOCATION_RESPONSE.INVOCATION_FAILED_TO_RUN_WITHOUT_KEYS_OR_SELECTED_METHOD,
+      );
+    }
     try {
       return await this.contractService.runInvocation(
         invocation.publicKey,


### PR DESCRIPTION
## Summary

we added validations so that the contract cannot be run without having keys or a method selected

## Details
Add new `conditional exception` in `invocation service`