### PR TITLE
Feature: Update name attribute of environment to unique

### DIFF
--- a/src/modules/enviroment/application/exceptions/enviroment-response.enum.ts
+++ b/src/modules/enviroment/application/exceptions/enviroment-response.enum.ts
@@ -5,4 +5,5 @@ export enum ENVIROMENT_RESPONSE {
   ENVIROMENT_FAILED_SAVE = 'Could not save variable, please try again',
   ENVIROMENT_FAILED_DELETED = 'Could not deleted variable, please try again',
   ENVIROMENT_FAILED_UPDATED = 'Could not updated variable, please try again',
+  ENVIRONMENT_EXISTS = 'The variable already exists',
 }

--- a/src/modules/enviroment/application/service/enviroment.service.ts
+++ b/src/modules/enviroment/application/service/enviroment.service.ts
@@ -54,6 +54,15 @@ export class EnviromentService {
         ENVIROMENT_RESPONSE.ENVIROMENT_NOT_FOUND_BY_COLLECTION_AND_USER,
       );
 
+    const enviromentExists = await this.enviromentRepository.findByNames(
+      [createEnviromentDto.name],
+      collection.id,
+    );
+
+    if (enviromentExists.length > 0) {
+      throw new BadRequestException(ENVIROMENT_RESPONSE.ENVIRONMENT_EXISTS);
+    }
+
     const enviromentValues: IEnviromentValues = {
       name: createEnviromentDto.name,
       value: createEnviromentDto.value,
@@ -61,6 +70,7 @@ export class EnviromentService {
       userId: user.id,
     };
     const enviroment = this.enviromentMapper.fromDtoToEntity(enviromentValues);
+
     const enviromentSaved = await this.enviromentRepository.save(enviroment);
 
     if (!enviromentSaved)

--- a/src/modules/enviroment/infrastructure/persistence/enviroment.schema.ts
+++ b/src/modules/enviroment/infrastructure/persistence/enviroment.schema.ts
@@ -10,6 +10,7 @@ export const EnviromentSchema = new EntitySchema<Enviroment>({
   columns: {
     ...baseColumnSchemas,
     name: {
+      unique: true,
       type: String,
     },
     value: {


### PR DESCRIPTION
### Summary

We add in the schema of the environments table that the name must be unique, in addition to adding a conditional and return an error if there is already a variable with the same name you want to create.

### Details

Update environment create method in `environment service`
Update `environment schema`


