### PR TITLE
Feat: Create migration to update type of attribute in environment schema

### DIFF
--- a/data/migrations/1702572347714-update-attribute-type-of-environment.ts
+++ b/data/migrations/1702572347714-update-attribute-type-of-environment.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class UpdateAttributeTypeOfEnvironment1702572347714
+  implements MigrationInterface
+{
+  name = 'UpdateAttributeTypeOfEnvironment1702572347714';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE \`enviroment\` DROP COLUMN \`value\``);
+    await queryRunner.query(
+      `ALTER TABLE \`enviroment\` ADD \`value\` text NOT NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE \`enviroment\` DROP COLUMN \`value\``);
+    await queryRunner.query(
+      `ALTER TABLE \`enviroment\` ADD \`value\` varchar(255) NOT NULL`,
+    );
+  }
+}

--- a/src/modules/enviroment/infrastructure/persistence/enviroment.schema.ts
+++ b/src/modules/enviroment/infrastructure/persistence/enviroment.schema.ts
@@ -14,7 +14,7 @@ export const EnviromentSchema = new EntitySchema<Enviroment>({
       type: String,
     },
     value: {
-      type: String,
+      type: 'text',
     },
     collectionId: {
       type: String,


### PR DESCRIPTION
### Summary

We modified the type of the value attribute of the environments table because the one we used before was a value that could not contain many bytes.


### Details

Update `environments schema`
Create migration to update `type` of attribute in environment table
