### PR TITLE
Feature: Add environment in contract id

### DIFF
--- a/src/modules/enviroment/application/service/enviroment.service.ts
+++ b/src/modules/enviroment/application/service/enviroment.service.ts
@@ -147,6 +147,10 @@ export class EnviromentService {
     return this.enviromentMapper.fromEntityToDto(enviroment);
   }
 
+  async findOneByName(name: string, collectionId: string) {
+    return await this.enviromentRepository.findOneByName(name, collectionId);
+  }
+
   async findByNames(names: string[], collectionId: string) {
     const envs = await this.enviromentRepository.findByNames(
       names,

--- a/src/modules/invocation/application/service/invocation.service.ts
+++ b/src/modules/invocation/application/service/invocation.service.ts
@@ -222,6 +222,17 @@ export class InvocationService {
 
     if (updateInvocationDto.contractId) {
       try {
+        const contractIdValue = invocation.getContractIdValue(
+          updateInvocationDto.contractId,
+        );
+        const environment = await this.enviromentService.findOneByName(
+          contractIdValue,
+          invocation.folder.collectionId,
+        );
+        updateInvocationDto.contractId = environment
+          ? environment.value
+          : contractIdValue;
+
         const generatedMethods =
           await this.contractService.generateMethodsFromContractId(
             updateInvocationDto.contractId,

--- a/src/modules/invocation/domain/__test__/invocation.domain.spec.ts
+++ b/src/modules/invocation/domain/__test__/invocation.domain.spec.ts
@@ -11,6 +11,7 @@ describe('Invocation', () => {
         '',
         '',
         '',
+        'futurenet',
         'folderId',
         'userId',
       );

--- a/src/modules/invocation/domain/__test__/invocation.domain.spec.ts
+++ b/src/modules/invocation/domain/__test__/invocation.domain.spec.ts
@@ -1,0 +1,26 @@
+import { Invocation } from '../invocation.domain';
+
+describe('Invocation', () => {
+  let invocation;
+  describe('Get ContractId Value', () => {
+    beforeEach(() => {
+      invocation = new Invocation(
+        'Invocation',
+        '',
+        '',
+        '',
+        '',
+        '',
+        'folderId',
+        'userId',
+      );
+    });
+    it('Should return the variable name without {{ }}', () => {
+      const envContractId = '{{contract_id}}';
+      const expectedValue = 'contract_id';
+      const contractId = invocation.getContractIdValue(envContractId);
+
+      expect(contractId).toEqual(expectedValue);
+    });
+  });
+});

--- a/src/modules/invocation/domain/invocation.domain.ts
+++ b/src/modules/invocation/domain/invocation.domain.ts
@@ -43,4 +43,10 @@ export class Invocation extends Base {
     this.id = id;
     this.selectedMethod = selectedMethod;
   }
+
+  getContractIdValue = (inputString: string): string => {
+    const regex = /{{(.*?)}}/g;
+    const contractId = inputString.replace(regex, (match, text) => text);
+    return contractId;
+  };
 }

--- a/src/modules/invocation/domain/invocation.domain.ts
+++ b/src/modules/invocation/domain/invocation.domain.ts
@@ -45,6 +45,7 @@ export class Invocation extends Base {
   }
 
   getContractIdValue = (inputString: string): string => {
+    // this regex outputs the {{ }} if the contract comes as an environment
     const regex = /{{(.*?)}}/g;
     const contractId = inputString.replace(regex, (match, text) => text);
     return contractId;

--- a/src/modules/invocation/interface/__test__/invocation.e2e.spec.ts
+++ b/src/modules/invocation/interface/__test__/invocation.e2e.spec.ts
@@ -310,6 +310,20 @@ describe('Invocation - [/invocation]', () => {
 
       expect(response.body.contractId).toEqual('new test contract');
     });
+    it('should update contract id with a environment', async () => {
+      jest
+        .spyOn(mockedContractService, 'generateMethodsFromContractId')
+        .mockResolvedValue([]);
+      const response = await request(app.getHttpServer())
+        .patch('/invocation')
+        .send({
+          id: 'invocation0',
+          contractId: '{{contract_id}}',
+        })
+        .expect(HttpStatus.OK);
+
+      expect(response.body.contractId).toEqual('contract_id');
+    });
     it('should update secretKey without removing publicKey', async () => {
       const response = await request(app.getHttpServer())
         .patch('/invocation')


### PR DESCRIPTION
### Summary

- Add receive an environment contract ID and convert it to a value

### Details

- Add function to transform `environment` in `contractId` 
- Add find one environment by name