### PR TITLE
Feat: Fix saving contract address as variable

### DIFF
--- a/src/modules/invocation/interface/__test__/fixture/Invocation.yml
+++ b/src/modules/invocation/interface/__test__/fixture/Invocation.yml
@@ -46,6 +46,7 @@ items:
     user: '@user0'
     folder: '@folder1'
     network: 'FUTURENET'
+    contractId: 'contractId'
     publicKey: 'publicKey5'
     secretKey: 'secretKey5'
     preInvocation: 'const a = () => "a"; a();'

--- a/src/modules/invocation/interface/__test__/invocation.e2e.spec.ts
+++ b/src/modules/invocation/interface/__test__/invocation.e2e.spec.ts
@@ -298,7 +298,7 @@ describe('Invocation - [/invocation]', () => {
         .expect(HttpStatus.NOT_FOUND);
     });
     it('should update contract id with a selected method', async () => {
-      const spy = jest
+      jest
         .spyOn(mockedContractService, 'generateMethodsFromContractId')
         .mockResolvedValue([]);
       const response = await request(app.getHttpServer())
@@ -316,15 +316,16 @@ describe('Invocation - [/invocation]', () => {
       jest
         .spyOn(mockedContractService, 'generateMethodsFromContractId')
         .mockResolvedValue([]);
+      const contractId = '{{contract_id}}';
       const response = await request(app.getHttpServer())
         .patch('/invocation')
         .send({
           id: 'invocation0',
-          contractId: '{{contract_id}}',
+          contractId,
         })
         .expect(HttpStatus.OK);
 
-      expect(response.body.contractId).toEqual('contract_id');
+      expect(response.body.contractId).toEqual(contractId);
     });
     it('should update secretKey without removing publicKey', async () => {
       const response = await request(app.getHttpServer())


### PR DESCRIPTION
### Summary

- Fix saving the contract address directly as it comes from the request

### Details

- Add a function to get the address of the contract to generate the methods or run the contract.

