### PR TITLE
Feature: Changing the network returns default values

### DIFF
--- a/src/modules/invocation/application/exceptions/invocation-response.enum.dto.ts
+++ b/src/modules/invocation/application/exceptions/invocation-response.enum.dto.ts
@@ -8,6 +8,7 @@ export enum INVOCATION_RESPONSE {
   Invocation_NOT_UPDATED = 'Unable to update invocation',
   INVOCATION_FOLDER_NOT_EXISTS = 'Folder does not exist or does not belong to you',
   INVOCATION_FAIL_GENERATE_METHODS_WITH_CONTRACT_ID = 'Methods cannot be generated with the provided contract ID',
+  INVOCATION_FAIL_DELETE_ALL_METHODS = 'The methods could not be removed. Please check if the IDs are valid',
   INVOCATION_FAIL_RUN_INVOCATION = 'Invocation execution failed',
   INVOCATION_FAIL_WITH_NEW_CONTRACT_AND_NEW_METHOD = 'Cannot set a new contract and method simultaneously',
   INVOCATION_FAIL_SELECTING_METHOD_WITHOUT_CONTRACT = 'Method selection requires a loaded contract',

--- a/src/modules/invocation/application/mapper/invocation.mapper.ts
+++ b/src/modules/invocation/application/mapper/invocation.mapper.ts
@@ -5,6 +5,7 @@ import { MethodMapper } from '@/modules/method/application/mapper/method.mapper'
 
 import { Invocation } from '../../domain/invocation.domain';
 import { InvocationResponseDto } from '../dto/invocation-response.dto';
+import { UpdateInvocationDto } from '../dto/update-invocation.dto';
 import {
   IInvocationValues,
   IUpdateInvocationValues,
@@ -111,5 +112,35 @@ export class InvocationMapper {
       selectedMethodId,
       id,
     );
+  }
+  fromUpdateDtoToInvocationValues(
+    updateInvocationDto: UpdateInvocationDto,
+    userId: string,
+  ): IUpdateInvocationValues {
+    const {
+      name,
+      secretKey,
+      publicKey,
+      preInvocation,
+      postInvocation,
+      contractId,
+      network,
+      folderId,
+      selectedMethodId,
+      id,
+    } = updateInvocationDto;
+    return {
+      name,
+      secretKey: network ? null : secretKey,
+      publicKey: network ? null : publicKey,
+      preInvocation: network ? null : preInvocation,
+      postInvocation: network ? null : postInvocation,
+      contractId: network ? null : contractId,
+      network,
+      folderId,
+      selectedMethodId,
+      userId,
+      id,
+    };
   }
 }

--- a/src/modules/invocation/application/service/invocation.service.ts
+++ b/src/modules/invocation/application/service/invocation.service.ts
@@ -272,22 +272,22 @@ export class InvocationService {
     }
 
     if (updateInvocationDto.network) {
-      this.contractService.changeNetwork(updateInvocationDto.network);
+      try {
+        this.contractService.changeNetwork(updateInvocationDto.network);
+        const methodIds = invocation.methods.map((method) => method.id);
+        await this.methodRepository.deleteAll(methodIds);
+      } catch (error) {
+        throw new BadRequestException(
+          INVOCATION_RESPONSE.INVOCATION_FAIL_DELETE_ALL_METHODS,
+        );
+      }
     }
 
-    const invocationValues: IUpdateInvocationValues = {
-      name: updateInvocationDto.name,
-      secretKey: updateInvocationDto.secretKey,
-      publicKey: updateInvocationDto.publicKey,
-      preInvocation: updateInvocationDto.preInvocation,
-      postInvocation: updateInvocationDto.postInvocation,
-      contractId: updateInvocationDto.contractId,
-      network: updateInvocationDto.network,
-      folderId: updateInvocationDto.folderId,
-      selectedMethodId: updateInvocationDto.selectedMethodId,
-      userId: user.id,
-      id: updateInvocationDto.id,
-    };
+    const invocationValues: IUpdateInvocationValues =
+      this.invocationMapper.fromUpdateDtoToInvocationValues(
+        updateInvocationDto,
+        user.id,
+      );
 
     const invocationMapped =
       this.invocationMapper.fromUpdateDtoToEntity(invocationValues);

--- a/src/modules/invocation/interface/__test__/invocation.e2e.spec.ts
+++ b/src/modules/invocation/interface/__test__/invocation.e2e.spec.ts
@@ -388,22 +388,48 @@ describe('Invocation - [/invocation]', () => {
     it('should change to TESTNET network', async () => {
       spy.mockResolvedValue({ network: 'TESTNET' });
 
-      await request(app.getHttpServer())
+      const responseExpected = expect.objectContaining({
+        secretKey: null,
+        publicKey: null,
+        preInvocation: null,
+        postInvocation: null,
+        contractId: null,
+        network: 'TESTNET',
+        id: 'invocation0',
+        methods: [],
+        selectedMethod: null,
+      });
+
+      const response = await request(app.getHttpServer())
         .patch('/invocation')
         .send({ network: 'TESTNET', id: 'invocation0' })
         .expect(HttpStatus.OK);
 
       expect(spy.mock.calls).toHaveLength(1);
+      expect(response.body).toEqual(responseExpected);
     });
     it('should change to FUTURENET network', async () => {
       spy.mockResolvedValue({ network: 'FUTURENET' });
 
-      await request(app.getHttpServer())
+      const responseExpected = expect.objectContaining({
+        secretKey: null,
+        publicKey: null,
+        preInvocation: null,
+        postInvocation: null,
+        contractId: null,
+        network: 'FUTURENET',
+        id: 'invocation0',
+        methods: [],
+        selectedMethod: null,
+      });
+
+      const response = await request(app.getHttpServer())
         .patch('/invocation')
         .send({ network: 'FUTURENET', id: 'invocation0' })
         .expect(HttpStatus.OK);
 
       expect(spy.mock.calls).toHaveLength(1);
+      expect(response.body).toEqual(responseExpected);
     });
   });
 


### PR DESCRIPTION
### Summary

- Fixed that switch network returns the invocation with default values

### Details

- Add delete all methods when change the network
- Add mapper to create a invocationValues to save in the data base
