### PR TITLE
Fix: Remove change network when update invocation

### DIFF
--- a/src/modules/invocation/application/service/invocation.service.ts
+++ b/src/modules/invocation/application/service/invocation.service.ts
@@ -281,7 +281,6 @@ export class InvocationService {
 
     if (updateInvocationDto.network) {
       try {
-        this.contractService.changeNetwork(updateInvocationDto.network);
         const methodIds = invocation.methods.map((method) => method.id);
         await this.methodRepository.deleteAll(methodIds);
       } catch (error) {

--- a/src/modules/invocation/interface/__test__/invocation.e2e.spec.ts
+++ b/src/modules/invocation/interface/__test__/invocation.e2e.spec.ts
@@ -370,13 +370,6 @@ describe('Invocation - [/invocation]', () => {
   });
 
   describe('Update Network - [PUT /invocation]', () => {
-    let spy;
-    beforeEach(() => {
-      spy = jest.spyOn(mockedContractService, 'changeNetwork');
-    });
-    afterEach(() => {
-      spy.mockClear();
-    });
     it('should throw error when the invocation id is incorrect', async () => {
       const response = await request(app.getHttpServer())
         .patch('/invocation')
@@ -388,8 +381,6 @@ describe('Invocation - [/invocation]', () => {
       );
     });
     it('should change to TESTNET network', async () => {
-      spy.mockResolvedValue({ network: 'TESTNET' });
-
       const responseExpected = expect.objectContaining({
         secretKey: null,
         publicKey: null,
@@ -407,12 +398,9 @@ describe('Invocation - [/invocation]', () => {
         .send({ network: 'TESTNET', id: 'invocation0' })
         .expect(HttpStatus.OK);
 
-      expect(spy.mock.calls).toHaveLength(1);
       expect(response.body).toEqual(responseExpected);
     });
     it('should change to FUTURENET network', async () => {
-      spy.mockResolvedValue({ network: 'FUTURENET' });
-
       const responseExpected = expect.objectContaining({
         secretKey: null,
         publicKey: null,
@@ -430,7 +418,6 @@ describe('Invocation - [/invocation]', () => {
         .send({ network: 'FUTURENET', id: 'invocation0' })
         .expect(HttpStatus.OK);
 
-      expect(spy.mock.calls).toHaveLength(1);
       expect(response.body).toEqual(responseExpected);
     });
   });


### PR DESCRIPTION
### Summary

- By updating the invocation we were changing the Soroban service network. It is not necessary, we change the Soroban network only when we load or update the contract.

### Details

- Remove change network when updating  invocation network

