### PR TITLE
Feat/team add collection

### DIFF
--- a/data/migrations/1708975898369-relations-collection-team.ts
+++ b/data/migrations/1708975898369-relations-collection-team.ts
@@ -1,0 +1,55 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class RelationsCollectionTeam1708975898369
+  implements MigrationInterface
+{
+  name = 'RelationsCollectionTeam1708975898369';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`collection\` DROP FOREIGN KEY \`FK_4f925485b013b52e32f43d430f6\``,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`collection\` DROP FOREIGN KEY \`FK_f8d2f64cb606c9329510b6f5944\``,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`collection\` CHANGE \`user_id\` \`user_id\` varchar(255) NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`collection\` DROP COLUMN \`team_id\``,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`collection\` ADD \`team_id\` varchar(255) NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`collection\` ADD CONSTRAINT \`FK_4f925485b013b52e32f43d430f6\` FOREIGN KEY (\`user_id\`) REFERENCES \`user\`(\`id\`) ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`collection\` ADD CONSTRAINT \`FK_f8d2f64cb606c9329510b6f5944\` FOREIGN KEY (\`team_id\`) REFERENCES \`team\`(\`id\`) ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`collection\` DROP FOREIGN KEY \`FK_f8d2f64cb606c9329510b6f5944\``,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`collection\` DROP FOREIGN KEY \`FK_4f925485b013b52e32f43d430f6\``,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`collection\` DROP COLUMN \`team_id\``,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`collection\` ADD \`team_id\` varchar(36) NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`collection\` CHANGE \`user_id\` \`user_id\` varchar(255) NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`collection\` ADD CONSTRAINT \`FK_f8d2f64cb606c9329510b6f5944\` FOREIGN KEY (\`team_id\`) REFERENCES \`team\`(\`id\`) ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`collection\` ADD CONSTRAINT \`FK_4f925485b013b52e32f43d430f6\` FOREIGN KEY (\`user_id\`) REFERENCES \`user\`(\`id\`) ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+}

--- a/src/modules/collection/application/dto/create-collection.dto.ts
+++ b/src/modules/collection/application/dto/create-collection.dto.ts
@@ -1,7 +1,11 @@
-import { IsNotEmpty, IsString } from 'class-validator';
+import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
 export class CreateCollectionDto {
   @IsNotEmpty()
   @IsString()
   name: string;
+
+  @IsOptional()
+  @IsString()
+  teamId: string;
 }

--- a/src/modules/collection/application/mapper/collection.mapper.ts
+++ b/src/modules/collection/application/mapper/collection.mapper.ts
@@ -18,12 +18,12 @@ export class CollectionMapper {
     private readonly enviromentMapper: EnviromentMapper,
   ) {}
   fromDtoToEntity(collectionData: ICollectionValues): Collection {
-    const { name, userId } = collectionData;
-    return new Collection(name, userId);
+    const { name, userId, teamId } = collectionData;
+    return new Collection(name, userId, teamId);
   }
   fromUpdateDtoToEntity(collectionData: IUpdateCollectionValues): Collection {
-    const { name, userId, id } = collectionData;
-    return new Collection(name, userId, id);
+    const { name, userId, teamId, id } = collectionData;
+    return new Collection(name, userId, teamId, id);
   }
   fromEntityToDto(collection: Collection): CollectionResponseDto {
     const { name, id, folders, enviroments } = collection;

--- a/src/modules/collection/application/repository/collection.repository.ts
+++ b/src/modules/collection/application/repository/collection.repository.ts
@@ -4,6 +4,7 @@ import { Collection } from '../../domain/collection.domain';
 
 export interface ICollectionRepository extends IBaseRepository<Collection> {
   findAllByUser(userId: string): Promise<Collection[]>;
+  findAllByTeam(teamId: string): Promise<Collection[]>;
   findOneByIds(id: string, userId: string): Promise<Collection>;
   update(collection: Collection): Promise<Collection>;
   delete(id: string): Promise<boolean>;

--- a/src/modules/collection/domain/collection.domain.ts
+++ b/src/modules/collection/domain/collection.domain.ts
@@ -6,14 +6,14 @@ import { Team } from '@/modules/team/domain/team.domain';
 
 export class Collection extends Base {
   name: string;
-  userId: string;
-  teamId: string;
+  userId?: string;
+  teamId?: string;
   id?: string;
   user?: User;
   team?: Team;
   folders?: Folder[];
   enviroments?: Enviroment[];
-  constructor(name: string, userId: string, teamId?: string, id?: string) {
+  constructor(name: string, userId?: string, teamId?: string, id?: string) {
     super();
     this.name = name;
     this.userId = userId;

--- a/src/modules/collection/domain/collection.domain.ts
+++ b/src/modules/collection/domain/collection.domain.ts
@@ -7,15 +7,17 @@ import { Team } from '@/modules/team/domain/team.domain';
 export class Collection extends Base {
   name: string;
   userId: string;
+  teamId: string;
   id?: string;
   user?: User;
   team?: Team;
   folders?: Folder[];
   enviroments?: Enviroment[];
-  constructor(name: string, userId: string, id?: string) {
+  constructor(name: string, userId: string, teamId?: string, id?: string) {
     super();
     this.name = name;
     this.userId = userId;
+    this.teamId = teamId;
     this.id = id;
   }
 }

--- a/src/modules/collection/infrastructure/persistence/collection.schema.ts
+++ b/src/modules/collection/infrastructure/persistence/collection.schema.ts
@@ -13,7 +13,12 @@ export const CollectionSchema = new EntitySchema<Collection>({
       type: 'varchar',
     },
     userId: {
-      type: String,
+      type: 'varchar',
+      nullable: true,
+    },
+    teamId: {
+      type: 'varchar',
+      nullable: true,
     },
   },
   relations: {

--- a/src/modules/collection/infrastructure/persistence/collection.typeorm.repository.ts
+++ b/src/modules/collection/infrastructure/persistence/collection.typeorm.repository.ts
@@ -53,6 +53,15 @@ export class CollectionRepository implements ICollectionRepository {
     });
   }
 
+  async findAllByTeam(teamId: string): Promise<Collection[]> {
+    return await this.repository.find({
+      order: { createdAt: 'DESC' },
+      where: {
+        teamId,
+      },
+    });
+  }
+
   async update(collection: Collection): Promise<Collection> {
     return await this.repository.preload(collection);
   }

--- a/src/modules/collection/interface/__test__/collection.e2e.spec.ts
+++ b/src/modules/collection/interface/__test__/collection.e2e.spec.ts
@@ -75,6 +75,20 @@ describe('Collection - [/collection]', () => {
 
       expect(response.body).toEqual({ name: 'test', id: expect.any(String) });
     });
+    it('It should create a new collection with a team id', async () => {
+      const response = await request(app.getHttpServer())
+        .post('/collection')
+        .send({
+          name: 'team test',
+          teamId: 'team1',
+        })
+        .expect(HttpStatus.CREATED);
+
+      expect(response.body).toEqual({
+        name: 'team test',
+        id: expect.any(String),
+      });
+    });
   });
 
   describe('Create all - [POST /collection/:id]', () => {
@@ -211,13 +225,26 @@ describe('Collection - [/collection]', () => {
       );
     });
 
+    it('should get one collection associated with a team', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/collection/collection2')
+        .expect(HttpStatus.OK);
+
+      expect(response.body).toEqual(
+        expect.objectContaining({
+          id: 'collection2',
+          name: 'collection2',
+        }),
+      );
+    });
+
     it('should throw error when try to get one collection not associated with a user', async () => {
       const response = await request(app.getHttpServer())
         .get('/collection/2')
         .expect(HttpStatus.NOT_FOUND);
 
       expect(response.body.message).toEqual(
-        COLLECTION_RESPONSE.COLLECTION_NOT_FOUND_BY_USER_AND_ID,
+        COLLECTION_RESPONSE.COLLECTION_NOT_FOUND_BY_ID,
       );
     });
   });
@@ -235,6 +262,21 @@ describe('Collection - [/collection]', () => {
       expect(response.body).toEqual({
         id: 'collection0',
         name: 'collection updated',
+      });
+    });
+    it('should update one collection associated with a team', async () => {
+      const response = await request(app.getHttpServer())
+        .patch('/collection')
+        .send({
+          name: 'team collection updated',
+          id: 'collection2',
+          teamId: 'team1',
+        })
+        .expect(HttpStatus.OK);
+
+      expect(response.body).toEqual({
+        id: 'collection2',
+        name: 'team collection updated',
       });
     });
   });
@@ -255,7 +297,7 @@ describe('Collection - [/collection]', () => {
         .expect(HttpStatus.NOT_FOUND);
 
       expect(response.body.message).toEqual(
-        COLLECTION_RESPONSE.COLLECTION_NOT_FOUND_BY_USER_AND_ID,
+        COLLECTION_RESPONSE.COLLECTION_NOT_FOUND_BY_ID,
       );
     });
   });

--- a/src/modules/collection/interface/__test__/fixture/Collection.yml
+++ b/src/modules/collection/interface/__test__/fixture/Collection.yml
@@ -1,11 +1,16 @@
 entity: Collection
 items:
   collection0:
-    id: "collection0"
+    id: 'collection0'
     name: 'collection0'
     user: '@user0'
 
   collection1:
-    id: "collection1"
+    id: 'collection1'
     name: 'collection1'
     user: '@user1'
+
+  collection2:
+    id: 'collection2'
+    name: 'collection2'
+    teamId: '@team1'

--- a/src/modules/collection/interface/__test__/fixture/Team.yml
+++ b/src/modules/collection/interface/__test__/fixture/Team.yml
@@ -1,0 +1,13 @@
+entity: Team
+items:
+  team0:
+    id: 'team0'
+    name: 'team0'
+    adminId: 'user0'
+    users: []
+
+  team1:
+    id: 'team1'
+    name: 'team1'
+    adminId: 'user1'
+    users: ['user0']

--- a/src/modules/collection/interface/collection.controller.ts
+++ b/src/modules/collection/interface/collection.controller.ts
@@ -61,11 +61,8 @@ export class CollectionController {
 
   @UseGuards(JwtAuthGuard)
   @Get('/:id')
-  async findOne(
-    @AuthUser() user: IUserResponse,
-    @Param('id') id: string,
-  ): Promise<CollectionResponseDto> {
-    return this.collectionService.findOneByIds(id, user.id);
+  async findOne(@Param('id') id: string): Promise<CollectionResponseDto> {
+    return this.collectionService.findOne(id);
   }
 
   @UseGuards(JwtAuthGuard)
@@ -109,8 +106,8 @@ export class CollectionController {
 
   @UseGuards(JwtAuthGuard)
   @Delete('/:id')
-  async delete(@AuthUser() user: IUserResponse, @Param('id') id: string) {
-    return this.collectionService.delete(id, user.id);
+  async delete(@Param('id') id: string) {
+    return this.collectionService.delete(id);
   }
 
   @UseGuards(JwtAuthGuard)

--- a/src/modules/team/application/service/team.service.ts
+++ b/src/modules/team/application/service/team.service.ts
@@ -9,6 +9,7 @@ import {
 import { AuthService } from '@/modules/auth/application/service/auth.service';
 import { User } from '@/modules/auth/domain/user.domain';
 import { IUserResponse } from '@/modules/auth/infrastructure/decorators/auth.decorators';
+import { CollectionService } from '@/modules/collection/application/service/collection.service';
 
 import { CreateTeamDto } from '../dto/create-team.dto';
 import { UpdateTeamDto } from '../dto/update-team.dto';
@@ -35,6 +36,8 @@ export class TeamService {
     private readonly teamMapper: TeamMapper,
     @Inject(TEAM_REPOSITORY)
     private readonly teamRepository: ITeamRepository,
+    @Inject(forwardRef(() => CollectionService))
+    private readonly collectionService: CollectionService,
     @Inject(forwardRef(() => AuthService))
     private readonly userService: AuthService,
   ) {}
@@ -66,6 +69,10 @@ export class TeamService {
     }
 
     return this.teamMapper.fromEntityToDto(team);
+  }
+
+  async findCollectionsByTeam(teamId: string) {
+    return await this.collectionService.findAllByTeam(teamId);
   }
 
   async create(createTeamDto: CreateTeamDto, user: IUserResponse) {

--- a/src/modules/team/interface/__test__/fixture/Collection.yml
+++ b/src/modules/team/interface/__test__/fixture/Collection.yml
@@ -1,11 +1,11 @@
 entity: Collection
 items:
   collection0:
-    id: "collection0"
+    id: 'collection0'
     name: 'collection0'
-    user: '@user0'
+    team: '@team0'
 
   collection1:
-    id: "collection1"
+    id: 'collection1'
     name: 'collection1'
     user: '@user1'

--- a/src/modules/team/interface/__test__/team.e2e.spec.ts
+++ b/src/modules/team/interface/__test__/team.e2e.spec.ts
@@ -127,6 +127,21 @@ describe('Team - [/team]', () => {
     });
   });
 
+  describe('GET all collections - [GET /team/:id/collections]', () => {
+    it('should get collections associated with a team', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/team/team0/collections')
+        .expect(HttpStatus.OK);
+
+      expect(response.body).toEqual([
+        expect.objectContaining({
+          id: 'collection0',
+          name: 'collection0',
+        }),
+      ]);
+    });
+  });
+
   describe('Update one - [PATCH /team]', () => {
     it('should update one team associated with a user', async () => {
       const response = await request(app.getHttpServer())

--- a/src/modules/team/interface/team.controller.ts
+++ b/src/modules/team/interface/team.controller.ts
@@ -36,6 +36,12 @@ export class TeamController {
   }
 
   @UseGuards(JwtAuthGuard)
+  @Get('/:id/collections')
+  async findCollectionsByTeam(@Param('id') id: string) {
+    return this.teamService.findCollectionsByTeam(id);
+  }
+
+  @UseGuards(JwtAuthGuard)
   @Post('/')
   async create(
     @Body() createTeamDto: CreateTeamDto,


### PR DESCRIPTION
### Summary

- Create a collection from `team.controller` is added.
- The CRUD of collections is corrected to be able to search directly by `collectionId` without depending on `userId` or `teamId`.

### Details

- Add `teamId` attribute in collection domain and dto
- Add `findAllByTeam`
- Fix collection and team tests

