### PR TITLE
Fix/remove user relations invocations

### DIFF
--- a/data/migrations/1709045674766-invocations-remove-user-id.ts
+++ b/data/migrations/1709045674766-invocations-remove-user-id.ts
@@ -1,0 +1,31 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class InvocationsRemoveUserId1709045674766
+  implements MigrationInterface
+{
+  name = 'InvocationsRemoveUserId1709045674766';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`invocation\` DROP FOREIGN KEY \`FK_122c60a426ba45acc4ee56651ad\``,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`invocation\` DROP COLUMN \`user_id\``,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`invitation\` ADD CONSTRAINT \`FK_e252ae8906b8e70c59c65e4dcbe\` FOREIGN KEY (\`team_id\`) REFERENCES \`team\`(\`id\`) ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`invitation\` DROP FOREIGN KEY \`FK_e252ae8906b8e70c59c65e4dcbe\``,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`invocation\` ADD \`user_id\` varchar(255) NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`invocation\` ADD CONSTRAINT \`FK_122c60a426ba45acc4ee56651ad\` FOREIGN KEY (\`user_id\`) REFERENCES \`user\`(\`id\`) ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+}

--- a/src/modules/invocation/application/mapper/invocation.mapper.ts
+++ b/src/modules/invocation/application/mapper/invocation.mapper.ts
@@ -28,7 +28,6 @@ export class InvocationMapper {
       postInvocation,
       contractId,
       folderId,
-      userId,
       network,
     } = createInvocationDto;
     return new Invocation(
@@ -39,7 +38,6 @@ export class InvocationMapper {
       postInvocation,
       contractId,
       folderId,
-      userId,
       network,
     );
   }
@@ -97,7 +95,6 @@ export class InvocationMapper {
       folderId,
       selectedMethodId,
       id,
-      userId,
     } = updateInvocationDto;
     return new Invocation(
       name,
@@ -107,7 +104,6 @@ export class InvocationMapper {
       postInvocation,
       contractId,
       folderId,
-      userId,
       network,
       selectedMethodId,
       id,
@@ -115,7 +111,6 @@ export class InvocationMapper {
   }
   fromUpdateDtoToInvocationValues(
     updateInvocationDto: UpdateInvocationDto,
-    userId: string,
   ): IUpdateInvocationValues {
     const {
       name,
@@ -139,7 +134,6 @@ export class InvocationMapper {
       network,
       folderId,
       selectedMethodId,
-      userId,
       id,
     };
   }

--- a/src/modules/invocation/domain/invocation.domain.ts
+++ b/src/modules/invocation/domain/invocation.domain.ts
@@ -1,5 +1,4 @@
 import { Base } from '@/common/domain/base.domain';
-import { User } from '@/modules/auth/domain/user.domain';
 import { Folder } from '@/modules/folder/domain/folder.domain';
 import { Method } from '@/modules/method/domain/method.domain';
 
@@ -11,11 +10,9 @@ export class Invocation extends Base {
   postInvocation: string;
   contractId: string;
   folderId: string;
-  userId: string;
   network: string;
   selectedMethodId?: string;
   folder?: Folder;
-  user?: User;
   methods?: Method[];
   selectedMethod?: Method;
   constructor(
@@ -26,7 +23,6 @@ export class Invocation extends Base {
     postInvocation: string,
     contractId: string,
     folderId: string,
-    userId: string,
     network: string,
     selectedMethodId?: string,
     id?: string,
@@ -40,7 +36,6 @@ export class Invocation extends Base {
     this.postInvocation = postInvocation;
     this.contractId = contractId;
     this.folderId = folderId;
-    this.userId = userId;
     this.network = network;
     this.selectedMethodId = selectedMethodId;
     this.id = id;

--- a/src/modules/invocation/infrastructure/persistence/invocation.schema.ts
+++ b/src/modules/invocation/infrastructure/persistence/invocation.schema.ts
@@ -35,9 +35,6 @@ export const InvocationSchema = new EntitySchema<Invocation>({
     folderId: {
       type: String,
     },
-    userId: {
-      type: String,
-    },
     network: {
       type: String,
     },
@@ -52,14 +49,6 @@ export const InvocationSchema = new EntitySchema<Invocation>({
       type: 'many-to-one',
       joinColumn: {
         name: 'folder_id',
-      },
-      onDelete: 'CASCADE',
-    },
-    user: {
-      target: 'User',
-      type: 'many-to-one',
-      joinColumn: {
-        name: 'user_id',
       },
       onDelete: 'CASCADE',
     },

--- a/src/modules/invocation/infrastructure/persistence/invocation.typeorm.repository.ts
+++ b/src/modules/invocation/infrastructure/persistence/invocation.typeorm.repository.ts
@@ -15,10 +15,10 @@ export class InvocationRepository implements IInvocationRepository {
 
   async save(invocation: Invocation): Promise<Invocation> {
     await this.repository.save(invocation);
-    return this.findOneByIds(invocation.id, invocation.userId);
+    return this.findOne(invocation.id);
   }
 
-  async findAll(userId: string): Promise<Invocation[]> {
+  async findAll(folderId: string): Promise<Invocation[]> {
     return await this.repository.find({
       order: { createdAt: 'DESC' },
       relations: {
@@ -27,23 +27,12 @@ export class InvocationRepository implements IInvocationRepository {
         methods: true,
       },
       where: {
-        userId,
+        folderId,
       },
     });
   }
 
   async findOne(id: string): Promise<Invocation> {
-    return await this.repository.findOne({
-      relations: {
-        methods: true,
-      },
-      where: {
-        id,
-      },
-    });
-  }
-
-  async findOneByIds(id: string, userId: string): Promise<Invocation> {
     return await this.repository.findOne({
       relations: {
         folder: true,
@@ -52,7 +41,20 @@ export class InvocationRepository implements IInvocationRepository {
       },
       where: {
         id,
-        userId,
+      },
+    });
+  }
+
+  async findOneByIds(id: string, folderId: string): Promise<Invocation> {
+    return await this.repository.findOne({
+      relations: {
+        folder: true,
+        selectedMethod: true,
+        methods: true,
+      },
+      where: {
+        id,
+        folderId,
       },
     });
   }

--- a/src/modules/invocation/interface/__test__/invocation.e2e.spec.ts
+++ b/src/modules/invocation/interface/__test__/invocation.e2e.spec.ts
@@ -115,28 +115,6 @@ describe('Invocation - [/invocation]', () => {
     });
   });
 
-  describe('Get all  - [GET /invocation]', () => {
-    it('should get all invocations associated with a user', async () => {
-      const responseExpected = expect.arrayContaining([
-        expect.objectContaining({ id: 'invocation0' }),
-        expect.objectContaining({ id: expect.any(String) }),
-      ]);
-      const response = await request(app.getHttpServer())
-        .get('/invocation')
-        .expect(HttpStatus.OK);
-
-      expect(response.body).toHaveLength(6);
-      expect(response.body).toEqual(responseExpected);
-    });
-    it('should only get invocations associated with a user', async () => {
-      const response = await request(app.getHttpServer())
-        .get('/invocation')
-        .expect(HttpStatus.OK);
-
-      expect(response.body).toHaveLength(6);
-    });
-  });
-
   describe('Get one  - [GET /invocation/:id]', () => {
     it('should get one invocation associated with a user', async () => {
       const responseExpected = expect.objectContaining({
@@ -156,11 +134,11 @@ describe('Invocation - [/invocation]', () => {
 
     it('should throw error when try to get one invocation not associated with a user', async () => {
       const response = await request(app.getHttpServer())
-        .get('/invocation/invocation1')
+        .get('/invocation/invocation')
         .expect(HttpStatus.NOT_FOUND);
 
       expect(response.body.message).toEqual(
-        INVOCATION_RESPONSE.Invocation_NOT_FOUND_BY_USER_AND_ID,
+        INVOCATION_RESPONSE.Invocation_NOT_FOUND,
       );
     });
   });
@@ -442,11 +420,11 @@ describe('Invocation - [/invocation]', () => {
 
     it('should throw error when try to delete one invocation not associated with a user', async () => {
       const response = await request(app.getHttpServer())
-        .delete('/invocation/invocation1')
+        .delete('/invocation/invocation')
         .expect(HttpStatus.NOT_FOUND);
 
       expect(response.body.message).toEqual(
-        INVOCATION_RESPONSE.Invocation_NOT_FOUND_BY_USER_AND_ID,
+        INVOCATION_RESPONSE.Invocation_NOT_FOUND,
       );
     });
   });

--- a/src/modules/invocation/interface/invocation.controller.ts
+++ b/src/modules/invocation/interface/invocation.controller.ts
@@ -27,11 +27,8 @@ export class InvocationController {
 
   @UseGuards(JwtAuthGuard)
   @Post('')
-  async create(
-    @Body() createInvocationDto: CreateInvocationDto,
-    @AuthUser() user: IUserResponse,
-  ) {
-    return this.invocationService.create(createInvocationDto, user);
+  async create(@Body() createInvocationDto: CreateInvocationDto) {
+    return this.invocationService.create(createInvocationDto);
   }
 
   @UseGuards(JwtAuthGuard)
@@ -42,14 +39,14 @@ export class InvocationController {
 
   @UseGuards(JwtAuthGuard)
   @Get('/:id')
-  findOne(@AuthUser() user: IUserResponse, @Param('id') id: string) {
-    return this.invocationService.findOneByIds(user, id);
+  findOne(@Param('id') id: string) {
+    return this.invocationService.findOne(id);
   }
 
   @UseGuards(JwtAuthGuard)
   @Get('/:id/run')
-  runInvocation(@AuthUser() user: IUserResponse, @Param('id') id: string) {
-    return this.invocationService.runInvocation(user, id);
+  runInvocation(@Param('id') id: string) {
+    return this.invocationService.runInvocation(id);
   }
 
   @UseGuards(JwtAuthGuard)
@@ -70,7 +67,7 @@ export class InvocationController {
 
   @UseGuards(JwtAuthGuard)
   @Delete('/:id')
-  delete(@AuthUser() user: IUserResponse, @Param('id') id: string) {
-    return this.invocationService.delete(user, id);
+  delete(@Param('id') id: string) {
+    return this.invocationService.delete(id);
   }
 }

--- a/src/modules/method/application/service/method.service.ts
+++ b/src/modules/method/application/service/method.service.ts
@@ -60,12 +60,6 @@ export class MethodService {
       createParamDto.invocationId,
     );
 
-    if (invocation?.userId !== user.id) {
-      throw new NotFoundException(
-        METHOD_RESPONSE.METHOD_NOT_FOUND_BY_USER_AND_ID,
-      );
-    }
-
     const methodValues: IMethodValues = {
       name: createParamDto.name,
       inputs: createParamDto.inputs,

--- a/src/modules/method/application/service/method.service.ts
+++ b/src/modules/method/application/service/method.service.ts
@@ -60,6 +60,10 @@ export class MethodService {
       createParamDto.invocationId,
     );
 
+    if (!invocation) {
+      throw new NotFoundException(METHOD_RESPONSE.METHOD_INVOCATION_NOT_FOUND);
+    }
+
     const methodValues: IMethodValues = {
       name: createParamDto.name,
       inputs: createParamDto.inputs,

--- a/src/modules/method/interface/__test__/method.e2e.spec.ts
+++ b/src/modules/method/interface/__test__/method.e2e.spec.ts
@@ -90,7 +90,7 @@ describe('Parameter - [/param]', () => {
         .expect(HttpStatus.NOT_FOUND);
 
       expect(response.body.message).toEqual(
-        METHOD_RESPONSE.METHOD_NOT_FOUND_BY_USER_AND_ID,
+        METHOD_RESPONSE.METHOD_INVOCATION_NOT_FOUND,
       );
     });
   });


### PR DESCRIPTION
### Summary

- The relation with the user is removed from the invocations module.
- This change is to be able to use the CRUD invocation on a team.

### Details

- Remove User relation in schema
- Remove userId from invocation module
- Add migration