### PR TITLE
Feat: Validate collection by team or user

### DIFF
--- a/src/modules/collection/application/exceptions/collection-response.enum.ts
+++ b/src/modules/collection/application/exceptions/collection-response.enum.ts
@@ -4,6 +4,7 @@ export enum COLLECTION_RESPONSE {
   COLLECTION_NOT_FOUND_BY_ID = 'Collection not found by id',
   COLLECTION_NOT_FOUND_BY_USER = 'Collection not found by user',
   COLLECTION_NOT_FOUND_BY_USER_AND_ID = 'The user of the collection and the logged in user do not match',
+  COLLECTION_NOT_FOUND_BY_TEAM_AND_ID = 'The admin of the team and the logged in user do not match',
   COLLECTION_FAILED_SAVE = 'Could not save collection, please try again',
   COLLECTION_FAILED_DELETED = 'Could not deleted collection, please try again',
   COLLECTION_FAILED_UPDATED = 'Could not updated collection, please try again',

--- a/src/modules/collection/infrastructure/persistence/collection.typeorm.repository.ts
+++ b/src/modules/collection/infrastructure/persistence/collection.typeorm.repository.ts
@@ -19,7 +19,12 @@ export class CollectionRepository implements ICollectionRepository {
 
   async findOne(id: string): Promise<Collection> {
     return await this.repository.findOne({
-      relations: { user: true, enviroments: true },
+      relations: {
+        team: true,
+        user: true,
+        folders: { invocations: true },
+        enviroments: true,
+      },
       where: {
         id,
       },
@@ -56,6 +61,12 @@ export class CollectionRepository implements ICollectionRepository {
   async findAllByTeam(teamId: string): Promise<Collection[]> {
     return await this.repository.find({
       order: { createdAt: 'DESC' },
+      relations: {
+        enviroments: true,
+        folders: {
+          invocations: { methods: true, selectedMethod: true },
+        },
+      },
       where: {
         teamId,
       },

--- a/src/modules/collection/interface/__test__/collection.e2e.spec.ts
+++ b/src/modules/collection/interface/__test__/collection.e2e.spec.ts
@@ -143,7 +143,7 @@ describe('Collection - [/collection]', () => {
         .get('/collection')
         .expect(HttpStatus.OK);
 
-      expect(response.body).toHaveLength(2);
+      expect(response.body).toHaveLength(3);
       expect(response.body).toEqual(responseExpected);
     });
     it('should only get collections associated with a user', async () => {
@@ -151,7 +151,7 @@ describe('Collection - [/collection]', () => {
         .get('/collection')
         .expect(HttpStatus.OK);
 
-      expect(response.body).toHaveLength(2);
+      expect(response.body).toHaveLength(3);
     });
     it('should get folders by collections id', async () => {
       const response = await request(app.getHttpServer())
@@ -237,14 +237,31 @@ describe('Collection - [/collection]', () => {
         }),
       );
     });
-
-    it('should throw error when try to get one collection not associated with a user', async () => {
+    it('should throw an error when trying to get a collection that does not exist', async () => {
       const response = await request(app.getHttpServer())
-        .get('/collection/2')
+        .get('/collection/collection')
         .expect(HttpStatus.NOT_FOUND);
 
       expect(response.body.message).toEqual(
         COLLECTION_RESPONSE.COLLECTION_NOT_FOUND_BY_ID,
+      );
+    });
+    it('should throw error when try to get one collection not associated with a user', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/collection/collection1')
+        .expect(HttpStatus.BAD_REQUEST);
+
+      expect(response.body.message).toEqual(
+        COLLECTION_RESPONSE.COLLECTION_NOT_FOUND_BY_USER_AND_ID,
+      );
+    });
+    it('should throw an error when trying to get a collection where the team admin does not match the user', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/collection/collection4')
+        .expect(HttpStatus.BAD_REQUEST);
+
+      expect(response.body.message).toEqual(
+        COLLECTION_RESPONSE.COLLECTION_NOT_FOUND_BY_TEAM_AND_ID,
       );
     });
   });
@@ -301,12 +318,24 @@ describe('Collection - [/collection]', () => {
       );
     });
   });
-  it('should delete all environments associated with a collection', async () => {
-    const collectionId = 'collection1';
-    const response = await request(app.getHttpServer())
-      .delete(`/collection/${collectionId}/environments`)
-      .expect(HttpStatus.OK);
 
-    expect(response.body).toEqual({});
+  describe('Delete All environments - [DELETE - /:id/environments]', () => {
+    it('should delete all environments associated with a collection and user', async () => {
+      const response = await request(app.getHttpServer())
+        .delete(`/collection/collection3/environments`)
+        .expect(HttpStatus.OK);
+
+      expect(response.body).toEqual({});
+    });
+
+    it('should throw error when try to delete all environments in the collection not associated with a user', async () => {
+      const response = await request(app.getHttpServer())
+        .delete(`/collection/collection1/environments`)
+        .expect(HttpStatus.BAD_REQUEST);
+
+      expect(response.body.message).toEqual(
+        COLLECTION_RESPONSE.COLLECTION_NOT_FOUND_BY_USER_AND_ID,
+      );
+    });
   });
 });

--- a/src/modules/collection/interface/__test__/fixture/Collection.yml
+++ b/src/modules/collection/interface/__test__/fixture/Collection.yml
@@ -13,4 +13,14 @@ items:
   collection2:
     id: 'collection2'
     name: 'collection2'
+    teamId: '@team0'
+
+  collection3:
+    id: 'collection3'
+    name: 'collection3'
+    user: '@user0'
+
+  collection4:
+    id: 'collection4'
+    name: 'collection4'
     teamId: '@team1'

--- a/src/modules/collection/interface/collection.controller.ts
+++ b/src/modules/collection/interface/collection.controller.ts
@@ -61,8 +61,11 @@ export class CollectionController {
 
   @UseGuards(JwtAuthGuard)
   @Get('/:id')
-  async findOne(@Param('id') id: string): Promise<CollectionResponseDto> {
-    return this.collectionService.findOne(id);
+  async findOne(
+    @AuthUser() user: IUserResponse,
+    @Param('id') id: string,
+  ): Promise<CollectionResponseDto> {
+    return this.collectionService.findOneByIds(id, user.id);
   }
 
   @UseGuards(JwtAuthGuard)
@@ -106,13 +109,13 @@ export class CollectionController {
 
   @UseGuards(JwtAuthGuard)
   @Delete('/:id')
-  async delete(@Param('id') id: string) {
-    return this.collectionService.delete(id);
+  async delete(@AuthUser() user: IUserResponse, @Param('id') id: string) {
+    return this.collectionService.delete(id, user.id);
   }
 
   @UseGuards(JwtAuthGuard)
   @Delete('/:id/environments')
-  async deleteAll(@Param('id') id: string) {
-    return this.collectionService.deleteAllEnvironments(id);
+  async deleteAll(@AuthUser() user: IUserResponse, @Param('id') id: string) {
+    return this.collectionService.deleteAllEnvironments(id, user.id);
   }
 }

--- a/src/modules/enviroment/interface/__test__/enviroment.e2e.spec.ts
+++ b/src/modules/enviroment/interface/__test__/enviroment.e2e.spec.ts
@@ -9,6 +9,7 @@ import { AppModule } from '@/app.module';
 import { COGNITO_SERVICE } from '@/modules/auth/application/repository/cognito.interface.service';
 import { JwtAuthGuard } from '@/modules/auth/infrastructure/guard/policy-auth.guard';
 import { JwtStrategy } from '@/modules/auth/infrastructure/jwt/jwt.strategy';
+import { COLLECTION_RESPONSE } from '@/modules/collection/application/exceptions/collection-response.enum';
 
 import { ENVIROMENT_RESPONSE } from '../../application/exceptions/enviroment-response.enum';
 
@@ -86,7 +87,7 @@ describe('Environment - [/environment]', () => {
         .expect(HttpStatus.NOT_FOUND);
 
       expect(response.body.message).toEqual(
-        ENVIROMENT_RESPONSE.ENVIROMENT_NOT_FOUND_BY_COLLECTION_AND_USER,
+        COLLECTION_RESPONSE.COLLECTION_NOT_FOUND_BY_ID,
       );
     });
     it('should update value of an environment if it already exists with the same name', async () => {

--- a/src/modules/folder/interface/__test__/folder.e2e.spec.ts
+++ b/src/modules/folder/interface/__test__/folder.e2e.spec.ts
@@ -9,6 +9,7 @@ import { AppModule } from '@/app.module';
 import { COGNITO_SERVICE } from '@/modules/auth/application/repository/cognito.interface.service';
 import { JwtAuthGuard } from '@/modules/auth/infrastructure/guard/policy-auth.guard';
 import { JwtStrategy } from '@/modules/auth/infrastructure/jwt/jwt.strategy';
+import { COLLECTION_RESPONSE } from '@/modules/collection/application/exceptions/collection-response.enum';
 
 import { FOLDER_RESPONSE } from '../../application/exceptions/folder-response.enum';
 
@@ -85,7 +86,7 @@ describe('Folder - [/folder]', () => {
         .expect(HttpStatus.NOT_FOUND);
 
       expect(response.body.message).toEqual(
-        FOLDER_RESPONSE.FOLDER_NOT_FOUND_BY_COLLECTION_AND_USER,
+        COLLECTION_RESPONSE.COLLECTION_NOT_FOUND_BY_ID,
       );
     });
   });


### PR DESCRIPTION
### Summary

- Validate the collection by user or team is added.
- If it is per user, it is validated that the logged in user and the userId match
- If it is by team, it is validated that the logged in user is equal to the `adminId` of the team

### Details

- Add find collection by ids (`collectionId`, `userId`)
- Add validate collection
