### PR TITLE
Feat: Add relations between Team, User and Role

### DIFF
--- a/data/migrations/1709560127906-create-add-relation-team-role-user-table.ts
+++ b/data/migrations/1709560127906-create-add-relation-team-role-user-table.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateAddRelationTeamRoleUserTable1709560127906
+  implements MigrationInterface
+{
+  name = 'CreateAddRelationTeamRoleUserTable1709560127906';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`user_role_team\` DROP FOREIGN KEY \`FK_633a35d35be5e6516c116aee550\``,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`user_role_team\` ADD CONSTRAINT \`FK_633a35d35be5e6516c116aee550\` FOREIGN KEY (\`team_id\`) REFERENCES \`team\`(\`id\`) ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`user_role_team\` DROP FOREIGN KEY \`FK_633a35d35be5e6516c116aee550\``,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`user_role_team\` ADD CONSTRAINT \`FK_633a35d35be5e6516c116aee550\` FOREIGN KEY (\`team_id\`) REFERENCES \`team\`(\`id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+  }
+}

--- a/src/modules/auth/application/exceptions/auth-error.ts
+++ b/src/modules/auth/application/exceptions/auth-error.ts
@@ -1,0 +1,4 @@
+export enum AUTH_RESPONSE {
+  USER_NOT_MEMBER_TEAM = 'Not authorized to access the team',
+  USER_ROLE_NOT_AUTHORIZED = 'You do not have the authorized role to perform this action',
+}

--- a/src/modules/auth/domain/role.enum.ts
+++ b/src/modules/auth/domain/role.enum.ts
@@ -1,0 +1,4 @@
+export enum Role {
+  ADMIN = 'ADMIN',
+  OWNER = 'OWNER',
+}

--- a/src/modules/auth/domain/user.domain.ts
+++ b/src/modules/auth/domain/user.domain.ts
@@ -1,15 +1,15 @@
 import { Base } from '@/common/domain/base.domain';
 import { Collection } from '@/modules/collection/domain/collection.domain';
 import { Folder } from '@/modules/folder/domain/folder.domain';
-import { Team } from '@/modules/team/domain/team.domain';
 import { Invitation } from '@/modules/invitation/domain/invitation.domain';
+import { UserRoleToTeam } from '@/modules/role/domain/role.domain';
 
 export class User extends Base {
   email: string;
   externalId: string;
   collections?: Collection[];
   folders?: Folder[];
-  teams?: Team[];
+  memberTeams?: UserRoleToTeam[];
   invitationsReceived?: Invitation[];
 
   constructor(email: string, externalId: string) {

--- a/src/modules/auth/infrastructure/guard/admin-role.guard.ts
+++ b/src/modules/auth/infrastructure/guard/admin-role.guard.ts
@@ -1,0 +1,41 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+
+import { TeamService } from '@/modules/team/application/service/team.service';
+
+import { AUTH_RESPONSE } from '../../application/exceptions/auth-error';
+import { Role } from '../../domain/role.enum';
+
+@Injectable()
+export class AdminRoleGuard implements CanActivate {
+  constructor(private readonly teamService: TeamService) {}
+
+  async canActivate(context: ExecutionContext) {
+    const req = context.switchToHttp().getRequest();
+    const { teamId } = req.params;
+
+    const team = await this.teamService.findOne(teamId);
+
+    const isMemberOfATeam = team.userMembers.some(
+      (member) => member.userId === req.user.id,
+    );
+
+    if (!isMemberOfATeam) {
+      throw new UnauthorizedException(AUTH_RESPONSE.USER_NOT_MEMBER_TEAM);
+    }
+
+    const userMember = team.userMembers.find(
+      (user) => user.userId === req.user.id,
+    );
+
+    if (userMember.role === Role.OWNER || userMember.role === Role.ADMIN) {
+      return true;
+    }
+
+    throw new UnauthorizedException(AUTH_RESPONSE.USER_ROLE_NOT_AUTHORIZED);
+  }
+}

--- a/src/modules/auth/infrastructure/guard/auth-team.guard.ts
+++ b/src/modules/auth/infrastructure/guard/auth-team.guard.ts
@@ -1,0 +1,32 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+
+import { TeamService } from '@/modules/team/application/service/team.service';
+
+import { AUTH_RESPONSE } from '../../application/exceptions/auth-error';
+
+@Injectable()
+export class AuthTeamGuard implements CanActivate {
+  constructor(private readonly teamService: TeamService) {}
+
+  async canActivate(context: ExecutionContext) {
+    const req = context.switchToHttp().getRequest();
+    const { teamId } = req.params;
+
+    const team = await this.teamService.findOne(teamId);
+
+    const isMemberOfATeam = team.userMembers.some(
+      (member) => member.userId === req.user.id,
+    );
+
+    if (!isMemberOfATeam) {
+      throw new UnauthorizedException(AUTH_RESPONSE.USER_NOT_MEMBER_TEAM);
+    }
+
+    return true;
+  }
+}

--- a/src/modules/auth/infrastructure/guard/owner-role.guard.ts
+++ b/src/modules/auth/infrastructure/guard/owner-role.guard.ts
@@ -1,0 +1,41 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+
+import { TeamService } from '@/modules/team/application/service/team.service';
+
+import { AUTH_RESPONSE } from '../../application/exceptions/auth-error';
+import { Role } from '../../domain/role.enum';
+
+@Injectable()
+export class OwnerRoleGuard implements CanActivate {
+  constructor(private readonly teamService: TeamService) {}
+
+  async canActivate(context: ExecutionContext) {
+    const req = context.switchToHttp().getRequest();
+    const { teamId } = req.params;
+
+    const team = await this.teamService.findOne(teamId);
+
+    const isMemberOfATeam = team.userMembers.some(
+      (member) => member.userId === req.user.id,
+    );
+
+    if (!isMemberOfATeam) {
+      throw new UnauthorizedException(AUTH_RESPONSE.USER_NOT_MEMBER_TEAM);
+    }
+
+    const userMember = team.userMembers.find(
+      (user) => user.userId === req.user.id,
+    );
+
+    if (userMember.role !== Role.OWNER) {
+      throw new UnauthorizedException(AUTH_RESPONSE.USER_ROLE_NOT_AUTHORIZED);
+    }
+
+    return true;
+  }
+}

--- a/src/modules/auth/infrastructure/persistence/user.schema.ts
+++ b/src/modules/auth/infrastructure/persistence/user.schema.ts
@@ -33,11 +33,10 @@ export const UserSchema = new EntitySchema<User>({
         name: 'user_id',
       },
     },
-    teams: {
-      target: 'Team',
-      type: 'many-to-many',
-      inverseSide: 'users',
-      onDelete: 'CASCADE',
+    memberTeams: {
+      target: 'UserRoleToTeam',
+      type: 'one-to-many',
+      inverseSide: 'user',
     },
     invitationsReceived: {
       target: 'Invitation',

--- a/src/modules/role/application/dto/response-user-role.dto.ts
+++ b/src/modules/role/application/dto/response-user-role.dto.ts
@@ -9,26 +9,18 @@ export class ResponseUserRoletoTeamDto {
   @IsNotEmpty()
   teamId: string;
 
+  @IsString()
   @IsNotEmpty()
-  user: {
-    id: string;
-    email: string;
-    role: string;
-  };
+  userId: string;
 
-  constructor(
-    id: string,
-    teamId: string,
-    userId: string,
-    userEmail: string,
-    role: string,
-  ) {
+  @IsString()
+  @IsNotEmpty()
+  role: string;
+
+  constructor(id: string, teamId: string, userId: string, role: string) {
     this.id = id;
     this.teamId = teamId;
-    this.user = {
-      id: userId,
-      email: userEmail,
-      role: role,
-    };
+    this.userId = userId;
+    this.role = role;
   }
 }

--- a/src/modules/role/application/mapper/role.mapper.ts
+++ b/src/modules/role/application/mapper/role.mapper.ts
@@ -18,7 +18,7 @@ export class UserRoleToTeamMapper {
     return new UserRoleToTeam(teamId, userId, role, id);
   }
   fromEntityToDto(userRole: UserRoleToTeam): ResponseUserRoletoTeamDto {
-    const { id, teamId, userId, user, role } = userRole;
-    return new ResponseUserRoletoTeamDto(id, teamId, userId, user.email, role);
+    const { id, teamId, userId, role } = userRole;
+    return new ResponseUserRoletoTeamDto(id, teamId, userId, role);
   }
 }

--- a/src/modules/role/application/repository/role.repository.ts
+++ b/src/modules/role/application/repository/role.repository.ts
@@ -7,6 +7,7 @@ export interface IUserRoleToTeamRepository
   findAllByTeamId(teamId: string): Promise<UserRoleToTeam[]>;
   findAllByUserId(userId: string): Promise<UserRoleToTeam[]>;
   findOneByIds(id: string, userId: string): Promise<UserRoleToTeam>;
+  saveAll(entities: UserRoleToTeam[]): Promise<UserRoleToTeam[]>;
   update(team: UserRoleToTeam): Promise<UserRoleToTeam>;
   delete(id: string): Promise<boolean>;
 }

--- a/src/modules/role/application/service/role.service.ts
+++ b/src/modules/role/application/service/role.service.ts
@@ -6,6 +6,7 @@ import {
 } from '@nestjs/common';
 
 import { CreateUserRoleToTeamDto } from '../dto/create-user-role.dto';
+import { ResponseUserRoletoTeamDto } from '../dto/response-user-role.dto';
 import { UpdateUserRoleToTeamDto } from '../dto/update-user-role.dto';
 import { ROLE_RESPONSE } from '../exceptions/role-response.enum';
 import { UserRoleToTeamMapper } from '../mapper/role.mapper';
@@ -89,6 +90,26 @@ export class UserRoleOnTeamService {
     } catch (error) {
       throw new BadRequestException(ROLE_RESPONSE.ROLE_FAILED_SAVED);
     }
+  }
+
+  async createAll(
+    userRoleToTeamData: UserRoleToTeamData[],
+  ): Promise<ResponseUserRoletoTeamDto[]> {
+    const usersRoleToSave = userRoleToTeamData.map((userRole) => {
+      return this.userRoleToTeamMapper.fromDtoToEntity(userRole);
+    });
+
+    const usersRoleSaved = await this.userRoleToTeamRepository.saveAll(
+      usersRoleToSave,
+    );
+
+    if (!usersRoleSaved) {
+      throw new BadRequestException(ROLE_RESPONSE.ROLE_FAILED_SAVED);
+    }
+
+    return usersRoleSaved.map((userRole) =>
+      this.userRoleToTeamMapper.fromEntityToDto(userRole),
+    );
   }
 
   async update(updateDto: UpdateUserRoleToTeamDto, userId: string) {

--- a/src/modules/role/infrastructure/persistence/role.schema.ts
+++ b/src/modules/role/infrastructure/persistence/role.schema.ts
@@ -30,6 +30,7 @@ export const UserRoleToTeamSchema = new EntitySchema<UserRoleToTeam>({
       type: 'many-to-one',
       target: 'Team',
       inverseSide: 'userRoleToTeam',
+      onDelete: 'CASCADE',
     },
   },
 });

--- a/src/modules/role/infrastructure/persistence/role.typeorm.repository.ts
+++ b/src/modules/role/infrastructure/persistence/role.typeorm.repository.ts
@@ -55,6 +55,10 @@ export class UserRoleToTeamRepository implements IUserRoleToTeamRepository {
     return this.repository.save(entity);
   }
 
+  async saveAll(entities: UserRoleToTeam[]): Promise<UserRoleToTeam[]> {
+    return this.repository.save(entities);
+  }
+
   async update(userRoleToTeam: UserRoleToTeam): Promise<UserRoleToTeam> {
     return await this.repository.preload(userRoleToTeam);
   }

--- a/src/modules/role/interface/__test__/role.e2e.spec.ts
+++ b/src/modules/role/interface/__test__/role.e2e.spec.ts
@@ -101,20 +101,14 @@ describe('UserRoleToTeam - [/role]', () => {
         expect.objectContaining({
           id: expect.any(String),
           teamId: 'team0',
-          user: {
-            id: 'user0',
-            email: 'user0',
-            role: 'ADMIN',
-          },
+          userId: 'user0',
+          role: 'ADMIN',
         }),
         expect.objectContaining({
           id: expect.any(String),
           teamId: 'team0',
-          user: {
-            id: 'user0',
-            email: 'user0',
-            role: 'ADMIN',
-          },
+          userId: 'user0',
+          role: 'ADMIN',
         }),
       ]);
 
@@ -135,11 +129,8 @@ describe('UserRoleToTeam - [/role]', () => {
       expect(response.body).toEqual({
         id: 'role0',
         teamId: 'team0',
-        user: {
-          id: 'user0',
-          email: 'user0',
-          role: 'ADMIN',
-        },
+        userId: 'user0',
+        role: 'ADMIN',
       });
     });
     it('should throw error when try to get one user role not associated with a user', async () => {

--- a/src/modules/role/role.module.ts
+++ b/src/modules/role/role.module.ts
@@ -19,5 +19,6 @@ import { UserRoleToTeamController } from './interface/role.controller';
       useClass: UserRoleToTeamRepository,
     },
   ],
+  exports: [UserRoleOnTeamService, UserRoleToTeamMapper],
 })
 export class UserRoleToTeamModule {}

--- a/src/modules/team/application/dto/response-team.dto.ts
+++ b/src/modules/team/application/dto/response-team.dto.ts
@@ -1,8 +1,8 @@
 import { IsArray, IsNotEmpty, IsString } from 'class-validator';
 
-import { User } from '@/modules/auth/domain/user.domain';
 import { CollectionResponseDto } from '@/modules/collection/application/dto/collection-response.dto';
 import { ResponseInvitationDto } from '@/modules/invitation/application/dto/response-invitation.dto';
+import { ResponseUserRoletoTeamDto } from '@/modules/role/application/dto/response-user-role.dto';
 
 export class TeamResponseDto {
   @IsString()
@@ -19,7 +19,7 @@ export class TeamResponseDto {
 
   @IsNotEmpty()
   @IsArray()
-  users: User[];
+  userMembers: ResponseUserRoletoTeamDto[];
 
   @IsNotEmpty()
   @IsArray()
@@ -33,14 +33,14 @@ export class TeamResponseDto {
     name: string,
     adminId: string,
     id: string,
-    users: User[],
+    userMembers: ResponseUserRoletoTeamDto[],
     invitations: ResponseInvitationDto[],
     collections: CollectionResponseDto[],
   ) {
     this.name = name;
     this.adminId = adminId;
     this.id = id;
-    this.users = users;
+    this.userMembers = userMembers;
     this.invitations = invitations;
     this.collections = collections;
   }

--- a/src/modules/team/application/mapper/team.mapper.ts
+++ b/src/modules/team/application/mapper/team.mapper.ts
@@ -2,6 +2,7 @@ import { Inject } from '@nestjs/common';
 
 import { CollectionMapper } from '@/modules/collection/application/mapper/collection.mapper';
 import { InvitationMapper } from '@/modules/invitation/application/mapper/invitation.mapper';
+import { UserRoleToTeamMapper } from '@/modules/role/application/mapper/role.mapper';
 
 import { Team } from '../../domain/team.domain';
 import { TeamResponseDto } from '../dto/response-team.dto';
@@ -13,20 +14,26 @@ export class TeamMapper {
     private readonly collectionMapper: CollectionMapper,
     @Inject(InvitationMapper)
     private readonly invitationMapper: InvitationMapper,
+    @Inject(UserRoleToTeamMapper)
+    private readonly userRoleToTeamMapper: UserRoleToTeamMapper,
   ) {}
 
   fromDtoToEntity(teamData: ITeamData): Team {
-    const { name, adminId, users } = teamData;
-    return new Team(name, adminId, users);
+    const { name, adminId } = teamData;
+    return new Team(name, adminId);
   }
 
   fromUpdateDtoToEntity(teamData: IUpdateTeamData): Team {
-    const { name, id, adminId, users } = teamData;
-    return new Team(name, adminId, users, id);
+    const { name, id, adminId } = teamData;
+    return new Team(name, adminId, id);
   }
 
   fromEntityToDto(team: Team): TeamResponseDto {
-    const { name, adminId, id, users, invitations, collections } = team;
+    const { name, adminId, id, invitations, collections, userMembers } = team;
+
+    const userMembersMapped = userMembers?.map((userMember) => {
+      return this.userRoleToTeamMapper.fromEntityToDto(userMember);
+    });
 
     const collectionsMapped = collections?.map((collection) => {
       return this.collectionMapper.fromEntityToDto(collection);
@@ -40,7 +47,7 @@ export class TeamMapper {
       name,
       adminId,
       id,
-      users,
+      userMembersMapped,
       invitationsMapped,
       collectionsMapped,
     );

--- a/src/modules/team/application/service/team.service.ts
+++ b/src/modules/team/application/service/team.service.ts
@@ -7,6 +7,7 @@ import {
 } from '@nestjs/common';
 
 import { AuthService } from '@/modules/auth/application/service/auth.service';
+import { Role } from '@/modules/auth/domain/role.enum';
 import { User } from '@/modules/auth/domain/user.domain';
 import { IUserResponse } from '@/modules/auth/infrastructure/decorators/auth.decorators';
 import { CollectionService } from '@/modules/collection/application/service/collection.service';
@@ -129,7 +130,7 @@ export class TeamService {
       return {
         teamId: team.id,
         userId: user.id,
-        role: 'ADMIN',
+        role: Role.ADMIN,
       };
     });
 
@@ -137,7 +138,7 @@ export class TeamService {
       userRoleToSave.push({
         teamId: team.id,
         userId: team.adminId,
-        role: 'OWNER',
+        role: Role.OWNER,
       });
     }
 

--- a/src/modules/team/domain/team.domain.ts
+++ b/src/modules/team/domain/team.domain.ts
@@ -1,20 +1,19 @@
 import { Base } from '@/common/domain/base.domain';
-import { User } from '@/modules/auth/domain/user.domain';
 import { Collection } from '@/modules/collection/domain/collection.domain';
 import { Invitation } from '@/modules/invitation/domain/invitation.domain';
+import { UserRoleToTeam } from '@/modules/role/domain/role.domain';
 
 export class Team extends Base {
   id?: string;
   name: string;
   adminId: string;
-  users: User[];
+  userMembers: UserRoleToTeam[];
   invitations?: Invitation[];
   collections?: Collection[];
-  constructor(name: string, adminId: string, users: User[], id?: string) {
+  constructor(name: string, adminId: string, id?: string) {
     super();
     this.name = name;
     this.adminId = adminId;
-    this.users = users;
     this.id = id;
   }
 }

--- a/src/modules/team/infrastructure/persistence/team.schema.ts
+++ b/src/modules/team/infrastructure/persistence/team.schema.ts
@@ -18,20 +18,10 @@ export const TeamSchema = new EntitySchema<Team>({
     },
   },
   relations: {
-    users: {
-      target: 'User',
-      type: 'many-to-many',
-      joinTable: {
-        name: 'team_user',
-        joinColumn: {
-          name: 'team_id',
-        },
-        inverseJoinColumn: {
-          name: 'user_id',
-        },
-      },
-      inverseSide: 'teams',
-      onDelete: 'CASCADE',
+    userMembers: {
+      target: 'UserRoleToTeam',
+      type: 'one-to-many',
+      inverseSide: 'team',
     },
     invitations: {
       target: 'Invitation',

--- a/src/modules/team/infrastructure/persistence/team.typeorm.repository.ts
+++ b/src/modules/team/infrastructure/persistence/team.typeorm.repository.ts
@@ -18,14 +18,14 @@ export class TeamRepository implements ITeamRepository {
   async findAllByUser(userId: string): Promise<Team[]> {
     return await this.repository.find({
       order: { createdAt: 'DESC' },
-      relations: { users: true, collections: true, invitations: true },
-      where: [{ adminId: userId }, { users: { id: userId } }],
+      relations: { userMembers: true, collections: true, invitations: true },
+      where: [{ adminId: userId }, { userMembers: { id: userId } }],
     });
   }
 
   async findOne(id: string): Promise<Team> {
     return await this.repository.findOne({
-      relations: { users: true, collections: true, invitations: true },
+      relations: { userMembers: true, collections: true, invitations: true },
       where: {
         id,
       },
@@ -34,7 +34,7 @@ export class TeamRepository implements ITeamRepository {
 
   async findOneByIds(id: string, adminId: string): Promise<Team> {
     return await this.repository.findOne({
-      relations: { users: true, collections: true },
+      relations: { userMembers: true, collections: true },
       where: {
         id,
         adminId,

--- a/src/modules/team/interface/__test__/fixture/Role.yml
+++ b/src/modules/team/interface/__test__/fixture/Role.yml
@@ -1,0 +1,25 @@
+entity: UserRoleToTeam
+items:
+  role0:
+    id: 'role0'
+    teamId: '@team0'
+    userId: '@user0'
+    role: 'OWNER'
+
+  role1:
+    id: 'role1'
+    teamId: '@team1'
+    userId: '@user1'
+    role: 'OWNER'
+
+  role2:
+    id: 'role2'
+    teamId: '@team1'
+    userId: '@user0'
+    role: 'ADMIN'
+
+  role3:
+    id: 'role3'
+    teamId: '@team2'
+    userId: '@user0'
+    role: 'USER'

--- a/src/modules/team/interface/__test__/fixture/Team.yml
+++ b/src/modules/team/interface/__test__/fixture/Team.yml
@@ -4,10 +4,22 @@ items:
     id: 'team0'
     name: 'team0'
     adminId: 'user0'
-    users: []
+    users: ['@user0']
 
   team1:
     id: 'team1'
     name: 'team1'
     adminId: 'user1'
     users: ['@user0']
+
+  team2:
+    id: 'team2'
+    name: 'team2'
+    adminId: 'user1'
+    users: ['@user0']
+
+  team3:
+    id: 'team3'
+    name: 'team3'
+    adminId: 'user1'
+    users: []

--- a/src/modules/team/interface/__test__/team.e2e.spec.ts
+++ b/src/modules/team/interface/__test__/team.e2e.spec.ts
@@ -76,7 +76,6 @@ describe('Team - [/team]', () => {
       expect(response.body).toEqual({
         name: 'test',
         adminId: 'user0',
-        users: [],
         id: expect.any(String),
       });
     });
@@ -93,16 +92,12 @@ describe('Team - [/team]', () => {
           adminId: 'user0',
           id: expect.any(String),
         }),
-        expect.objectContaining({
-          adminId: 'user1',
-          id: expect.any(String),
-        }),
       ]);
       const response = await request(app.getHttpServer())
         .get('/team')
         .expect(HttpStatus.OK);
 
-      expect(response.body).toHaveLength(3);
+      expect(response.body).toHaveLength(2);
       expect(response.body).toEqual(responseExpected);
     });
   });
@@ -118,7 +113,7 @@ describe('Team - [/team]', () => {
           id: 'team0',
           name: 'team0',
           adminId: 'user0',
-          users: [],
+          userMembers: [],
         }),
       );
     });
@@ -161,12 +156,6 @@ describe('Team - [/team]', () => {
         name: 'team updated',
         id: 'team0',
         adminId: 'user0',
-        users: expect.arrayContaining([
-          expect.objectContaining({
-            email: 'user1',
-            id: 'user1',
-          }),
-        ]),
       });
     });
     it('should throw error when try to update one team not associated with a user', async () => {

--- a/src/modules/team/interface/team.controller.ts
+++ b/src/modules/team/interface/team.controller.ts
@@ -13,6 +13,8 @@ import {
   AuthUser,
   IUserResponse,
 } from '@/modules/auth/infrastructure/decorators/auth.decorators';
+import { AuthTeamGuard } from '@/modules/auth/infrastructure/guard/auth-team.guard';
+import { OwnerRoleGuard } from '@/modules/auth/infrastructure/guard/owner-role.guard';
 import { JwtAuthGuard } from '@/modules/auth/infrastructure/guard/policy-auth.guard';
 
 import { CreateTeamDto } from '../application/dto/create-team.dto';
@@ -20,28 +22,27 @@ import { UpdateTeamDto } from '../application/dto/update-team.dto';
 import { TeamService } from '../application/service/team.service';
 
 @Controller('team')
+@UseGuards(JwtAuthGuard)
 export class TeamController {
   constructor(private readonly teamService: TeamService) {}
 
-  @UseGuards(JwtAuthGuard)
   @Get('/')
   async findAllByUser(@AuthUser() user: IUserResponse) {
     return this.teamService.findAllByUser(user.id);
   }
 
-  @UseGuards(JwtAuthGuard)
-  @Get('/:id')
-  async findOne(@Param('id') id: string) {
-    return this.teamService.findOne(id);
+  @UseGuards(AuthTeamGuard)
+  @Get('/:teamId')
+  async findOne(@Param('teamId') teamId: string) {
+    return this.teamService.findOne(teamId);
   }
 
-  @UseGuards(JwtAuthGuard)
-  @Get('/:id/collections')
-  async findCollectionsByTeam(@Param('id') id: string) {
-    return this.teamService.findCollectionsByTeam(id);
+  @UseGuards(AuthTeamGuard)
+  @Get('/:teamId/collections')
+  async findCollectionsByTeam(@Param('teamId') teamId: string) {
+    return this.teamService.findCollectionsByTeam(teamId);
   }
 
-  @UseGuards(JwtAuthGuard)
   @Post('/')
   async create(
     @Body() createTeamDto: CreateTeamDto,
@@ -50,7 +51,6 @@ export class TeamController {
     return this.teamService.create(createTeamDto, user);
   }
 
-  @UseGuards(JwtAuthGuard)
   @Patch('/')
   async update(
     @AuthUser() user: IUserResponse,
@@ -59,9 +59,12 @@ export class TeamController {
     return this.teamService.update(updateTeamDto, user.id);
   }
 
-  @UseGuards(JwtAuthGuard)
-  @Delete('/:id')
-  async delete(@AuthUser() user: IUserResponse, @Param('id') id: string) {
-    return this.teamService.delete(id, user.id);
+  @UseGuards(OwnerRoleGuard)
+  @Delete('/:teamId')
+  async delete(
+    @AuthUser() user: IUserResponse,
+    @Param('teamId') teamId: string,
+  ) {
+    return this.teamService.delete(teamId, user.id);
   }
 }

--- a/src/modules/team/team.module.ts
+++ b/src/modules/team/team.module.ts
@@ -4,6 +4,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthModule } from '../auth/auth.module';
 import { CollectionModule } from '../collection/collection.module';
 import { InvitationModule } from '../invitation/invitation.module';
+import { UserRoleToTeamModule } from '../role/role.module';
 import { TeamMapper } from './application/mapper/team.mapper';
 import { TEAM_REPOSITORY } from './application/repository/team.repository';
 import { TeamService } from './application/service/team.service';
@@ -17,6 +18,7 @@ import { TeamController } from './interface/team.controller';
     forwardRef(() => CollectionModule),
     forwardRef(() => AuthModule),
     forwardRef(() => InvitationModule),
+    forwardRef(() => UserRoleToTeamModule),
   ],
   controllers: [TeamController],
   providers: [


### PR DESCRIPTION
### Summary

- Add relations between Team, User and Role
- An intermediate column is added between Team and User to manage roles.
- If the team is deleted, the roles are cascaded out.


- Adds 3 guards for the teams
- A guard is in charge of verifying if the user belongs to a team.
- Another guard is in charge of verifying if the user is an ADMIN role or higher.
- Another guard is in charge of verifying if the user is an OWNER role.

### Details

- Add relations between Team, User and Role
- Add createAll in role repository and team.service
- Fix role mapper and dto
- Add role module in team module
- Add migration
- Add tests


- Add 3 guards for teams
- Add auth-error and role.enum
- Add guards in team.controller
- Add tests


