### PR TITLE
Feat: Remove adminId from Team module

### DIFF
--- a/data/migrations/1709748131638-remove-admin-id-from-team-table.ts
+++ b/data/migrations/1709748131638-remove-admin-id-from-team-table.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class RemoveAdminIdFromTeamTable1709748131638
+  implements MigrationInterface
+{
+  name = 'RemoveAdminIdFromTeamTable1709748131638';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE \`team\` DROP COLUMN \`admin_id\``);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`team\` ADD \`admin_id\` varchar(255) NOT NULL`,
+    );
+  }
+}

--- a/src/modules/team/application/dto/response-team.dto.ts
+++ b/src/modules/team/application/dto/response-team.dto.ts
@@ -11,10 +11,6 @@ export class TeamResponseDto {
 
   @IsString()
   @IsNotEmpty()
-  adminId: string;
-
-  @IsString()
-  @IsNotEmpty()
   name: string;
 
   @IsNotEmpty()
@@ -31,14 +27,12 @@ export class TeamResponseDto {
 
   constructor(
     name: string,
-    adminId: string,
     id: string,
     userMembers: ResponseUserRoletoTeamDto[],
     invitations: ResponseInvitationDto[],
     collections: CollectionResponseDto[],
   ) {
     this.name = name;
-    this.adminId = adminId;
     this.id = id;
     this.userMembers = userMembers;
     this.invitations = invitations;

--- a/src/modules/team/application/mapper/team.mapper.ts
+++ b/src/modules/team/application/mapper/team.mapper.ts
@@ -19,17 +19,17 @@ export class TeamMapper {
   ) {}
 
   fromDtoToEntity(teamData: ITeamData): Team {
-    const { name, adminId } = teamData;
-    return new Team(name, adminId);
+    const { name } = teamData;
+    return new Team(name);
   }
 
   fromUpdateDtoToEntity(teamData: IUpdateTeamData): Team {
-    const { name, id, adminId } = teamData;
-    return new Team(name, adminId, id);
+    const { name, id } = teamData;
+    return new Team(name, id);
   }
 
   fromEntityToDto(team: Team): TeamResponseDto {
-    const { name, adminId, id, invitations, collections, userMembers } = team;
+    const { name, id, invitations, collections, userMembers } = team;
 
     const userMembersMapped = userMembers?.map((userMember) => {
       return this.userRoleToTeamMapper.fromEntityToDto(userMember);
@@ -45,7 +45,6 @@ export class TeamMapper {
 
     return new TeamResponseDto(
       name,
-      adminId,
       id,
       userMembersMapped,
       invitationsMapped,

--- a/src/modules/team/domain/team.domain.ts
+++ b/src/modules/team/domain/team.domain.ts
@@ -6,14 +6,12 @@ import { UserRoleToTeam } from '@/modules/role/domain/role.domain';
 export class Team extends Base {
   id?: string;
   name: string;
-  adminId: string;
   userMembers: UserRoleToTeam[];
   invitations?: Invitation[];
   collections?: Collection[];
-  constructor(name: string, adminId: string, id?: string) {
+  constructor(name: string, id?: string) {
     super();
     this.name = name;
-    this.adminId = adminId;
     this.id = id;
   }
 }

--- a/src/modules/team/infrastructure/persistence/team.schema.ts
+++ b/src/modules/team/infrastructure/persistence/team.schema.ts
@@ -13,9 +13,6 @@ export const TeamSchema = new EntitySchema<Team>({
       type: 'varchar',
       name: 'name',
     },
-    adminId: {
-      type: String,
-    },
   },
   relations: {
     userMembers: {

--- a/src/modules/team/infrastructure/persistence/team.typeorm.repository.ts
+++ b/src/modules/team/infrastructure/persistence/team.typeorm.repository.ts
@@ -19,7 +19,7 @@ export class TeamRepository implements ITeamRepository {
     return await this.repository.find({
       order: { createdAt: 'DESC' },
       relations: { userMembers: true, collections: true, invitations: true },
-      where: [{ adminId: userId }, { userMembers: { id: userId } }],
+      where: [{ userMembers: { userId } }],
     });
   }
 
@@ -32,12 +32,12 @@ export class TeamRepository implements ITeamRepository {
     });
   }
 
-  async findOneByIds(id: string, adminId: string): Promise<Team> {
+  async findOneByIds(id: string, userId: string): Promise<Team> {
     return await this.repository.findOne({
       relations: { userMembers: true, collections: true },
       where: {
         id,
-        adminId,
+        userMembers: { userId },
       },
     });
   }

--- a/src/modules/team/interface/__test__/team.e2e.spec.ts
+++ b/src/modules/team/interface/__test__/team.e2e.spec.ts
@@ -76,7 +76,6 @@ describe('Team - [/team]', () => {
 
       expect(response.body).toEqual({
         name: 'test',
-        adminId: 'user0',
         id: expect.any(String),
       });
     });
@@ -86,19 +85,36 @@ describe('Team - [/team]', () => {
     it('should get all teams associated with a user', async () => {
       const responseExpected = expect.arrayContaining([
         expect.objectContaining({
-          adminId: 'user0',
           id: expect.any(String),
+          userMembers: expect.arrayContaining([
+            expect.objectContaining({ userId: 'user0' }),
+          ]),
         }),
         expect.objectContaining({
-          adminId: 'user0',
           id: expect.any(String),
+          userMembers: expect.arrayContaining([
+            expect.objectContaining({ userId: 'user0' }),
+          ]),
+        }),
+        expect.objectContaining({
+          id: expect.any(String),
+          userMembers: expect.arrayContaining([
+            expect.objectContaining({ userId: 'user0' }),
+          ]),
+        }),
+        expect.objectContaining({
+          id: expect.any(String),
+          userMembers: expect.arrayContaining([
+            expect.objectContaining({ userId: 'user0' }),
+          ]),
         }),
       ]);
+
       const response = await request(app.getHttpServer())
         .get('/team')
         .expect(HttpStatus.OK);
 
-      expect(response.body).toHaveLength(2);
+      expect(response.body).toHaveLength(4);
       expect(response.body).toEqual(responseExpected);
     });
   });
@@ -113,7 +129,6 @@ describe('Team - [/team]', () => {
         expect.objectContaining({
           id: 'team0',
           name: 'team0',
-          adminId: 'user0',
         }),
       );
     });
@@ -158,10 +173,9 @@ describe('Team - [/team]', () => {
   describe('Update one - [PATCH /team]', () => {
     it('should update one team associated with a user', async () => {
       const response = await request(app.getHttpServer())
-        .patch('/team')
+        .patch('/team/team0')
         .send({
           name: 'team updated',
-          id: 'team0',
           usersEmails: ['user1'],
         })
         .expect(HttpStatus.OK);
@@ -169,20 +183,28 @@ describe('Team - [/team]', () => {
       expect(response.body).toEqual({
         name: 'team updated',
         id: 'team0',
-        adminId: 'user0',
       });
     });
     it('should throw error when try to update one team not associated with a user', async () => {
       const response = await request(app.getHttpServer())
-        .patch('/team')
+        .patch('/team/2')
         .send({
           name: 'team updated',
-          id: '2',
         })
         .expect(HttpStatus.NOT_FOUND);
 
+      expect(response.body.message).toEqual(TEAM_RESPONSE.TEAM_NOT_FOUND_BY_ID);
+    });
+    it('should throw error when try to update one team with a user without the admin role', async () => {
+      const response = await request(app.getHttpServer())
+        .patch('/team/team2')
+        .send({
+          name: 'team updated',
+        })
+        .expect(HttpStatus.UNAUTHORIZED);
+
       expect(response.body.message).toEqual(
-        TEAM_RESPONSE.TEAM_NOT_FOUND_BY_USER_AND_ID,
+        AUTH_RESPONSE.USER_ROLE_NOT_AUTHORIZED,
       );
     });
   });

--- a/src/modules/team/interface/team.controller.ts
+++ b/src/modules/team/interface/team.controller.ts
@@ -13,12 +13,12 @@ import {
   AuthUser,
   IUserResponse,
 } from '@/modules/auth/infrastructure/decorators/auth.decorators';
+import { AdminRoleGuard } from '@/modules/auth/infrastructure/guard/admin-role.guard';
 import { AuthTeamGuard } from '@/modules/auth/infrastructure/guard/auth-team.guard';
 import { OwnerRoleGuard } from '@/modules/auth/infrastructure/guard/owner-role.guard';
 import { JwtAuthGuard } from '@/modules/auth/infrastructure/guard/policy-auth.guard';
 
 import { CreateTeamDto } from '../application/dto/create-team.dto';
-import { UpdateTeamDto } from '../application/dto/update-team.dto';
 import { TeamService } from '../application/service/team.service';
 
 @Controller('team')
@@ -51,12 +51,14 @@ export class TeamController {
     return this.teamService.create(createTeamDto, user);
   }
 
-  @Patch('/')
+  @UseGuards(AdminRoleGuard)
+  @Patch('/:teamId')
   async update(
     @AuthUser() user: IUserResponse,
-    @Body() updateTeamDto: UpdateTeamDto,
+    @Body() updateTeamDto: CreateTeamDto,
+    @Param('teamId') teamId: string,
   ) {
-    return this.teamService.update(updateTeamDto, user.id);
+    return this.teamService.update({ ...updateTeamDto, id: teamId }, user.id);
   }
 
   @UseGuards(OwnerRoleGuard)


### PR DESCRIPTION
### Summary

- The `adminId` attribute is removed from the Team module,
- When having team roles and assigning the team to an `OWNER` Role, it is not necessary to have this attribute.
- Added the ability to update a team being an Admin role or higher.

### Details
- Remove `adminId` from team.module
- Add `AdminRoleGuard` in update Team
- Add create owner role in `createAllUserRole`
- Add migration and tests

