### PR TITLE
Feat: Add CRUD folder to user and team

### DIFF
--- a/src/modules/collection/interface/__test__/collection.e2e.spec.ts
+++ b/src/modules/collection/interface/__test__/collection.e2e.spec.ts
@@ -148,8 +148,8 @@ describe('Collection - [/collection]', () => {
       expect(response.body).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            id: expect.any(String),
-            name: expect.any(String),
+            id: 'folder0',
+            name: 'folder0',
           }),
         ]),
       );
@@ -298,6 +298,20 @@ describe('Collection - [/collection]', () => {
 
         expect(response.body).toHaveLength(2);
         expect(response.body).toEqual(responseExpected);
+      });
+      it('should get all folders by collections and team id', async () => {
+        const response = await request(app.getHttpServer())
+          .get('/team/team0/collection/collection3/folders')
+          .expect(HttpStatus.OK);
+
+        expect(response.body).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              id: 'folder1',
+              name: 'folder1',
+            }),
+          ]),
+        );
       });
       it('should throw error when try to get collections with a team not associated a user', async () => {
         const response = await request(app.getHttpServer())

--- a/src/modules/collection/interface/__test__/fixture/Folder.yml
+++ b/src/modules/collection/interface/__test__/fixture/Folder.yml
@@ -3,5 +3,9 @@ items:
   folder0:
     id: 'folder0'
     name: 'folder0'
-    user: '@user0'
     collection: '@collection0'
+
+  folder1:
+    id: 'folder1'
+    name: 'folder1'
+    collection: '@collection3'

--- a/src/modules/folder/application/exceptions/folder-response.enum.ts
+++ b/src/modules/folder/application/exceptions/folder-response.enum.ts
@@ -1,9 +1,8 @@
 export enum FOLDER_RESPONSE {
   FOLDER_NOT_FOUND = 'Folder not found',
   FOLDERS_NOT_FOUND = 'Folders not found',
-  FOLDER_NOT_FOUND_BY_COLLECTION_ID = 'The user of the collection and the logged in user do not match',
-  FOLDER_NOT_FOUND_BY_USER_ID = 'The user id does not match',
-  FOLDER_NOT_FOUND_BY_TEAM_ID = 'The admin of team and user id does not match',
+  FOLDER_NOT_FOUND_BY_USER_ID = 'Folder not found by user id',
+  FOLDER_NOT_FOUND_BY_TEAM_ID = 'Folder not found by team id',
   FOLDER_COLLECTION_NOT_FOUND = 'The collection does not exist',
   FOLDER_FAILED_SAVE = 'Could not save folder, please try again',
   FOLDER_FAILED_DELETED = 'Could not deleted folder, please try again',

--- a/src/modules/folder/application/repository/folder.repository.ts
+++ b/src/modules/folder/application/repository/folder.repository.ts
@@ -3,12 +3,8 @@ import { IBaseRepository } from '@/common/application/base.repository';
 import { Folder } from '../../domain/folder.domain';
 
 export interface IFolderRepository extends IBaseRepository<Folder> {
-  findAll(userId: string): Promise<Folder[]>;
-  findAllByCollectionId(
-    collectionId: string,
-    userId: string,
-  ): Promise<Folder[]>;
-  findOneByIds(id: string, userId: string): Promise<Folder>;
+  findOneByFolderAndUserId(id: string, userId: string): Promise<Folder>;
+  findOneByFolderAndTeamId(id: string, teamId: string): Promise<Folder>;
   update(folder: Folder): Promise<Folder>;
   delete(id: string): Promise<boolean>;
 }

--- a/src/modules/folder/application/service/folder.service.ts
+++ b/src/modules/folder/application/service/folder.service.ts
@@ -8,7 +8,6 @@ import {
 import { IUserResponse } from '@/modules/auth/infrastructure/decorators/auth.decorators';
 import { CollectionService } from '@/modules/collection/application/service/collection.service';
 
-import { Folder } from '../../domain/folder.domain';
 import { CreateFolderDto } from '../dto/create-folder.dto';
 import { FolderResponseDto } from '../dto/folder-response.dto';
 import { UpdateFolderDto } from '../dto/update-folder.dto';
@@ -39,20 +38,29 @@ export class FolderService {
     private readonly collectionService: CollectionService,
   ) {}
 
-  async create(
+  async createByTeam(
+    createFolderDto: CreateFolderDto,
+    teamId: string,
+  ): Promise<FolderResponseDto> {
+    await this.collectionService.findOneByCollectionAndTeamId(
+      createFolderDto.collectionId,
+      teamId,
+    );
+    return await this.create(createFolderDto);
+  }
+
+  async createByUser(
     createFolderDto: CreateFolderDto,
     user: IUserResponse,
   ): Promise<FolderResponseDto> {
-    const collection =
-      await this.collectionService.findOneByCollectionAndUserId(
-        createFolderDto.collectionId,
-        user.id,
-      );
+    await this.collectionService.findOneByCollectionAndUserId(
+      createFolderDto.collectionId,
+      user.id,
+    );
+    return await this.create(createFolderDto);
+  }
 
-    if (!collection) {
-      throw new NotFoundException(FOLDER_RESPONSE.FOLDER_COLLECTION_NOT_FOUND);
-    }
-
+  async create(createFolderDto: CreateFolderDto): Promise<FolderResponseDto> {
     const foldervalues: IFolderValues = {
       name: createFolderDto.name,
       collectionId: createFolderDto.collectionId,
@@ -67,48 +75,65 @@ export class FolderService {
     return this.folderMapper.fromEntityToDto(folderSaved);
   }
 
-  async findAll(user: IUserResponse): Promise<FolderResponseDto[]> {
-    const folders = await this.folderRepository.findAll(user.id);
-    if (!folders) {
-      throw new NotFoundException(FOLDER_RESPONSE.FOLDERS_NOT_FOUND);
-    }
-    return folders.map((folder) => this.folderMapper.fromEntityToDto(folder));
-  }
-
-  async findOne(id: string): Promise<FolderResponseDto> {
-    const folder = await this.folderRepository.findOne(id);
+  async findOneByFolderAndUserId(
+    id: string,
+    userId: string,
+  ): Promise<FolderResponseDto> {
+    const folder = await this.folderRepository.findOneByFolderAndUserId(
+      id,
+      userId,
+    );
     if (!folder) {
-      throw new NotFoundException(FOLDER_RESPONSE.FOLDER_NOT_FOUND);
+      throw new NotFoundException(FOLDER_RESPONSE.FOLDER_NOT_FOUND_BY_USER_ID);
     }
     return this.folderMapper.fromEntityToDto(folder);
   }
 
-  async findOneByIds(id: string, userId: string) {
-    const folder = await this.folderRepository.findOne(id);
-    await this.validateFolderByUser(folder, userId);
+  async findOneByFolderAndTeamId(
+    folderId: string,
+    teamId: string,
+  ): Promise<FolderResponseDto> {
+    const folder = await this.folderRepository.findOneByFolderAndTeamId(
+      folderId,
+      teamId,
+    );
+    if (!folder) {
+      throw new NotFoundException(FOLDER_RESPONSE.FOLDER_NOT_FOUND_BY_TEAM_ID);
+    }
     return this.folderMapper.fromEntityToDto(folder);
   }
 
-  async update(
+  async updateByUser(
     updateFolderDto: UpdateFolderDto,
     userId: string,
   ): Promise<FolderResponseDto> {
-    await this.findOneByIds(updateFolderDto.id, userId);
+    await this.findOneByFolderAndUserId(updateFolderDto.id, userId);
 
     if (updateFolderDto.collectionId) {
-      const collection =
-        await this.collectionService.findOneByCollectionAndUserId(
-          updateFolderDto.collectionId,
-          userId,
-        );
-
-      if (!collection) {
-        throw new NotFoundException(
-          FOLDER_RESPONSE.FOLDER_COLLECTION_NOT_FOUND,
-        );
-      }
+      await this.collectionService.findOneByCollectionAndUserId(
+        updateFolderDto.collectionId,
+        userId,
+      );
     }
+    return await this.update(updateFolderDto);
+  }
 
+  async updateByTeam(
+    updateFolderDto: UpdateFolderDto,
+    teamId: string,
+  ): Promise<FolderResponseDto> {
+    await this.findOneByFolderAndTeamId(updateFolderDto.id, teamId);
+
+    if (updateFolderDto.collectionId) {
+      await this.collectionService.findOneByCollectionAndTeamId(
+        updateFolderDto.id,
+        teamId,
+      );
+    }
+    return await this.update(updateFolderDto);
+  }
+
+  async update(updateFolderDto: UpdateFolderDto): Promise<FolderResponseDto> {
     const folderValues: IUpdateFolderValues = {
       name: updateFolderDto.name,
       collectionId: updateFolderDto.collectionId,
@@ -128,28 +153,22 @@ export class FolderService {
     return this.folderMapper.fromEntityToDto(folderSaved);
   }
 
-  async delete(id: string, userId: string): Promise<boolean> {
-    await this.findOneByIds(id, userId);
+  async deleteByUser(folderId: string, userId: string): Promise<boolean> {
+    await this.findOneByFolderAndUserId(folderId, userId);
+    return await this.delete(folderId);
+  }
 
+  async deleteByTeam(folderId: string, teamId: string): Promise<boolean> {
+    await this.findOneByFolderAndTeamId(folderId, teamId);
+    return await this.delete(folderId);
+  }
+
+  async delete(id: string): Promise<boolean> {
     const folderDeleted = this.folderRepository.delete(id);
     if (!folderDeleted) {
       throw new BadRequestException(FOLDER_RESPONSE.FOLDER_FAILED_DELETED);
     }
 
     return folderDeleted;
-  }
-
-  async validateFolderByUser(folder: Folder, userId: string) {
-    if (!folder) {
-      throw new NotFoundException(FOLDER_RESPONSE.FOLDER_NOT_FOUND);
-    }
-
-    const { collection } = folder;
-
-    if (collection.user && collection.user.id !== userId) {
-      throw new BadRequestException(
-        FOLDER_RESPONSE.FOLDER_NOT_FOUND_BY_COLLECTION_ID,
-      );
-    }
   }
 }

--- a/src/modules/folder/folder.module.ts
+++ b/src/modules/folder/folder.module.ts
@@ -3,20 +3,23 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { CollectionModule } from '../collection/collection.module';
 import { InvocationModule } from '../invocation/invocation.module';
+import { TeamModule } from '../team/team.module';
 import { FolderMapper } from './application/mapper/folder.mapper';
 import { FOLDER_REPOSITORY } from './application/repository/folder.repository';
 import { FolderService } from './application/service/folder.service';
 import { FolderSchema } from './infrastructure/persistence/folder.schema';
 import { FolderRepository } from './infrastructure/persistence/folder.typeorm.repository';
-import { FolderController } from './interface/folder.controller';
+import { FolderTeamController } from './interface/folder-team.controller';
+import { FolderUserController } from './interface/folder.controller';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([FolderSchema]),
     forwardRef(() => CollectionModule),
     forwardRef(() => InvocationModule),
+    TeamModule,
   ],
-  controllers: [FolderController],
+  controllers: [FolderUserController, FolderTeamController],
   providers: [
     FolderService,
     FolderMapper,

--- a/src/modules/folder/infrastructure/persistence/folder.typeorm.repository.ts
+++ b/src/modules/folder/infrastructure/persistence/folder.typeorm.repository.ts
@@ -17,51 +17,40 @@ export class FolderRepository implements IFolderRepository {
     return this.repository.save(folder);
   }
 
-  async findAll(collectionId: string): Promise<Folder[]> {
-    return await this.repository.find({
-      order: { createdAt: 'DESC' },
-      relations: {
-        invocations: { selectedMethod: true },
-      },
-      where: {
-        collectionId,
-      },
-    });
-  }
-
-  async findAllByCollectionId(collectionId: string): Promise<Folder[]> {
-    return await this.repository.find({
-      order: { createdAt: 'DESC' },
-      relations: {
-        invocations: { selectedMethod: false },
-      },
-      where: {
-        collectionId,
-      },
-    });
-  }
-
   async findOne(id: string): Promise<Folder> {
     return await this.repository.findOne({
-      relations: {
-        collection: { team: true, user: true },
-        invocations: { selectedMethod: false },
-      },
       where: {
         id,
       },
     });
   }
 
-  async findOneByIds(id: string, collectionId: string): Promise<Folder> {
+  async findOneByFolderAndUserId(id: string, userId: string): Promise<Folder> {
     return await this.repository.findOne({
       relations: {
-        collection: { team: true, user: true },
+        collection: true,
         invocations: { selectedMethod: true },
       },
       where: {
         id,
-        collectionId,
+        collection: {
+          userId,
+        },
+      },
+    });
+  }
+
+  async findOneByFolderAndTeamId(id: string, teamId: string): Promise<Folder> {
+    return await this.repository.findOne({
+      relations: {
+        collection: true,
+        invocations: { selectedMethod: true },
+      },
+      where: {
+        id,
+        collection: {
+          teamId,
+        },
       },
     });
   }

--- a/src/modules/folder/interface/__test__/fixture/Collection.yml
+++ b/src/modules/folder/interface/__test__/fixture/Collection.yml
@@ -19,3 +19,8 @@ items:
     id: 'collection3'
     name: 'collection3'
     teamId: '@team1'
+
+  collection4:
+    id: 'collection4'
+    name: 'collection4'
+    teamId: '@team2'

--- a/src/modules/folder/interface/__test__/fixture/Folder.yml
+++ b/src/modules/folder/interface/__test__/fixture/Folder.yml
@@ -19,3 +19,8 @@ items:
     id: 'folder3'
     name: 'folder3'
     collection: '@collection3'
+
+  folder4:
+    id: 'folder4'
+    name: 'folder4'
+    collection: '@collection4'

--- a/src/modules/folder/interface/__test__/fixture/Role.yml
+++ b/src/modules/folder/interface/__test__/fixture/Role.yml
@@ -1,0 +1,25 @@
+entity: UserRoleToTeam
+items:
+  role0:
+    id: 'role0'
+    teamId: '@team0'
+    userId: '@user0'
+    role: 'OWNER'
+
+  role1:
+    id: 'role1'
+    teamId: '@team1'
+    userId: '@user1'
+    role: 'OWNER'
+
+  role2:
+    id: 'role2'
+    teamId: '@team1'
+    userId: '@user0'
+    role: 'ADMIN'
+
+  role3:
+    id: 'role3'
+    teamId: '@team2'
+    userId: '@user0'
+    role: 'USER'

--- a/src/modules/folder/interface/__test__/fixture/Team.yml
+++ b/src/modules/folder/interface/__test__/fixture/Team.yml
@@ -11,3 +11,9 @@ items:
     name: 'team1'
     adminId: 'user1'
     users: ['user0']
+
+  team2:
+    id: 'team2'
+    name: 'team2'
+    adminId: 'user1'
+    users: ['user0']

--- a/src/modules/folder/interface/__test__/folder.e2e.spec.ts
+++ b/src/modules/folder/interface/__test__/folder.e2e.spec.ts
@@ -6,6 +6,7 @@ import * as request from 'supertest';
 import { loadFixtures } from '@data/util/loader';
 
 import { AppModule } from '@/app.module';
+import { AUTH_RESPONSE } from '@/modules/auth/application/exceptions/auth-error';
 import { COGNITO_SERVICE } from '@/modules/auth/application/repository/cognito.interface.service';
 import { JwtAuthGuard } from '@/modules/auth/infrastructure/guard/policy-auth.guard';
 import { JwtStrategy } from '@/modules/auth/infrastructure/jwt/jwt.strategy';
@@ -65,7 +66,7 @@ describe('Folder - [/folder]', () => {
   });
 
   describe('Create one  - [POST /folder]', () => {
-    it('It should create a new folder', async () => {
+    it('should create a new folder', async () => {
       const response = await request(app.getHttpServer())
         .post('/folder')
         .send({
@@ -103,31 +104,22 @@ describe('Folder - [/folder]', () => {
         invocations: expect.any(Array),
       });
     });
-    it('should get one folder associated with a team', async () => {
-      const response = await request(app.getHttpServer())
-        .get('/folder/folder2')
-        .expect(HttpStatus.OK);
-
-      expect(response.body).toEqual({
-        id: 'folder2',
-        name: 'folder2',
-        invocations: expect.any(Array),
-      });
-    });
     it('should throw error when try to get one folder not exist', async () => {
       const response = await request(app.getHttpServer())
         .get('/folder/folder')
         .expect(HttpStatus.NOT_FOUND);
 
-      expect(response.body.message).toEqual(FOLDER_RESPONSE.FOLDER_NOT_FOUND);
+      expect(response.body.message).toEqual(
+        FOLDER_RESPONSE.FOLDER_NOT_FOUND_BY_USER_ID,
+      );
     });
     it('should throw error when try to get one folder not associated with a user', async () => {
       const response = await request(app.getHttpServer())
         .get('/folder/folder1')
-        .expect(HttpStatus.BAD_REQUEST);
+        .expect(HttpStatus.NOT_FOUND);
 
       expect(response.body.message).toEqual(
-        FOLDER_RESPONSE.FOLDER_NOT_FOUND_BY_COLLECTION_ID,
+        FOLDER_RESPONSE.FOLDER_NOT_FOUND_BY_USER_ID,
       );
     });
   });
@@ -156,7 +148,9 @@ describe('Folder - [/folder]', () => {
         })
         .expect(HttpStatus.NOT_FOUND);
 
-      expect(response.body.message).toEqual(FOLDER_RESPONSE.FOLDER_NOT_FOUND);
+      expect(response.body.message).toEqual(
+        FOLDER_RESPONSE.FOLDER_NOT_FOUND_BY_USER_ID,
+      );
     });
   });
 
@@ -174,7 +168,155 @@ describe('Folder - [/folder]', () => {
         .delete('/folder/folder')
         .expect(HttpStatus.NOT_FOUND);
 
-      expect(response.body.message).toEqual(FOLDER_RESPONSE.FOLDER_NOT_FOUND);
+      expect(response.body.message).toEqual(
+        FOLDER_RESPONSE.FOLDER_NOT_FOUND_BY_USER_ID,
+      );
+    });
+  });
+
+  describe('By Team - [/team/:teamId/folder]', () => {
+    const validRoute = '/team/team0/folder';
+    const invalidRoute = '/team/team1/folder';
+    const unauthorizeRoute = '/team/team2/folder';
+
+    describe('Create one  - [POST /folder]', () => {
+      it('should create a new folder with a team', async () => {
+        const response = await request(app.getHttpServer())
+          .post(`${validRoute}`)
+          .send({
+            name: 'test',
+            collectionId: 'collection2',
+          })
+          .expect(HttpStatus.CREATED);
+
+        expect(response.body).toEqual({ name: 'test', id: expect.any(String) });
+      });
+      it('should throw error when try to create a new folder not associated with the team and collections', async () => {
+        const response = await request(app.getHttpServer())
+          .post(`${invalidRoute}`)
+          .send({
+            name: 'test',
+            collectionId: 'collection2',
+          })
+          .expect(HttpStatus.NOT_FOUND);
+
+        expect(response.body.message).toEqual(
+          COLLECTION_RESPONSE.COLLECTION_NOT_FOUND_BY_TEAM,
+        );
+      });
+      it('should throw an unauthorized error when trying to create a new folder with a user without the required role', async () => {
+        const response = await request(app.getHttpServer())
+          .post(`${unauthorizeRoute}`)
+          .send({
+            name: 'test',
+            collectionId: 'collection4',
+          })
+          .expect(HttpStatus.UNAUTHORIZED);
+
+        expect(response.body.message).toEqual(
+          AUTH_RESPONSE.USER_ROLE_NOT_AUTHORIZED,
+        );
+      });
+    });
+    describe('Get one  - [GET /folder/:id]', () => {
+      it('should get one folder associated with a team', async () => {
+        const response = await request(app.getHttpServer())
+          .get(`${validRoute}/folder2`)
+          .expect(HttpStatus.OK);
+
+        expect(response.body).toEqual({
+          id: 'folder2',
+          name: 'folder2',
+          invocations: expect.any(Array),
+        });
+      });
+      it('should throw error when try to get one folder not exist', async () => {
+        const response = await request(app.getHttpServer())
+          .get(`${invalidRoute}/folder`)
+          .expect(HttpStatus.NOT_FOUND);
+
+        expect(response.body.message).toEqual(
+          FOLDER_RESPONSE.FOLDER_NOT_FOUND_BY_TEAM_ID,
+        );
+      });
+      it('should throw error when try to get one folder not associated with a team', async () => {
+        const response = await request(app.getHttpServer())
+          .get(`${invalidRoute}/folder1`)
+          .expect(HttpStatus.NOT_FOUND);
+
+        expect(response.body.message).toEqual(
+          FOLDER_RESPONSE.FOLDER_NOT_FOUND_BY_TEAM_ID,
+        );
+      });
+    });
+    describe('Update one  - [PUT /folder/:id]', () => {
+      it('should update one folder associated with a team', async () => {
+        const response = await request(app.getHttpServer())
+          .patch(`${validRoute}`)
+          .send({
+            name: 'folder2 updated',
+            id: 'folder2',
+          })
+          .expect(HttpStatus.OK);
+
+        expect(response.body).toEqual({
+          id: 'folder2',
+          name: 'folder2 updated',
+        });
+      });
+      it('should throw error when try to update one folder not associated with a team', async () => {
+        const response = await request(app.getHttpServer())
+          .patch(`${invalidRoute}`)
+          .send({
+            name: 'folder updated',
+            id: 'folder',
+          })
+          .expect(HttpStatus.NOT_FOUND);
+
+        expect(response.body.message).toEqual(
+          FOLDER_RESPONSE.FOLDER_NOT_FOUND_BY_TEAM_ID,
+        );
+      });
+      it('should throw an unauthorized error when try to update a new folder with a user without the required role', async () => {
+        const response = await request(app.getHttpServer())
+          .patch(`${unauthorizeRoute}`)
+          .send({
+            name: 'folder updated',
+            id: 'folder4',
+          })
+          .expect(HttpStatus.UNAUTHORIZED);
+
+        expect(response.body.message).toEqual(
+          AUTH_RESPONSE.USER_ROLE_NOT_AUTHORIZED,
+        );
+      });
+    });
+    describe('Delete one  - [DELETE /folder/:id]', () => {
+      it('should delete one folder associated with a team', async () => {
+        const response = await request(app.getHttpServer())
+          .delete(`${validRoute}/folder2`)
+          .expect(HttpStatus.OK);
+
+        expect(response.body).toEqual({});
+      });
+      it('should throw error when try to delete one folder not associated with a team', async () => {
+        const response = await request(app.getHttpServer())
+          .delete(`${invalidRoute}/folder1`)
+          .expect(HttpStatus.NOT_FOUND);
+
+        expect(response.body.message).toEqual(
+          FOLDER_RESPONSE.FOLDER_NOT_FOUND_BY_TEAM_ID,
+        );
+      });
+      it('should throw an unauthorized error when try to delete a new folder with a user without the required role', async () => {
+        const response = await request(app.getHttpServer())
+          .delete(`${unauthorizeRoute}/folder4`)
+          .expect(HttpStatus.UNAUTHORIZED);
+
+        expect(response.body.message).toEqual(
+          AUTH_RESPONSE.USER_ROLE_NOT_AUTHORIZED,
+        );
+      });
     });
   });
 });

--- a/src/modules/folder/interface/folder-team.controller.ts
+++ b/src/modules/folder/interface/folder-team.controller.ts
@@ -1,0 +1,53 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+
+import { AdminRoleGuard } from '@/modules/auth/infrastructure/guard/admin-role.guard';
+import { AuthTeamGuard } from '@/modules/auth/infrastructure/guard/auth-team.guard';
+import { JwtAuthGuard } from '@/modules/auth/infrastructure/guard/policy-auth.guard';
+
+import { CreateFolderDto } from '../application/dto/create-folder.dto';
+import { UpdateFolderDto } from '../application/dto/update-folder.dto';
+import { FolderService } from '../application/service/folder.service';
+
+@Controller('/team/:teamId/folder')
+@UseGuards(JwtAuthGuard, AuthTeamGuard)
+export class FolderTeamController {
+  constructor(private readonly folderService: FolderService) {}
+
+  @UseGuards(AdminRoleGuard)
+  @Post('')
+  async create(
+    @Body() createFolderDto: CreateFolderDto,
+    @Param('teamId') teamId: string,
+  ) {
+    return this.folderService.createByTeam(createFolderDto, teamId);
+  }
+
+  @Get('/:id')
+  findOne(@Param('teamId') teamId: string, @Param('id') id: string) {
+    return this.folderService.findOneByFolderAndTeamId(id, teamId);
+  }
+
+  @UseGuards(AdminRoleGuard)
+  @Patch('')
+  update(
+    @Body() updateFoldertDto: UpdateFolderDto,
+    @Param('teamId') teamId: string,
+  ) {
+    return this.folderService.updateByTeam(updateFoldertDto, teamId);
+  }
+
+  @UseGuards(AdminRoleGuard)
+  @Delete('/:id')
+  delete(@Param('teamId') teamId: string, @Param('id') id: string) {
+    return this.folderService.deleteByTeam(id, teamId);
+  }
+}

--- a/src/modules/folder/interface/folder.controller.ts
+++ b/src/modules/folder/interface/folder.controller.ts
@@ -20,42 +20,33 @@ import { UpdateFolderDto } from '../application/dto/update-folder.dto';
 import { FolderService } from '../application/service/folder.service';
 
 @Controller('folder')
-export class FolderController {
+@UseGuards(JwtAuthGuard)
+export class FolderUserController {
   constructor(private readonly folderService: FolderService) {}
 
-  @UseGuards(JwtAuthGuard)
   @Post('')
   async create(
     @AuthUser() user: IUserResponse,
     @Body() createFolderDto: CreateFolderDto,
   ) {
-    return this.folderService.create(createFolderDto, user);
+    return this.folderService.createByUser(createFolderDto, user);
   }
 
-  @UseGuards(JwtAuthGuard)
-  @Get('')
-  findAll(@AuthUser() user: IUserResponse) {
-    return this.folderService.findAll(user);
-  }
-
-  @UseGuards(JwtAuthGuard)
   @Get('/:id')
   findOne(@AuthUser() user: IUserResponse, @Param('id') id: string) {
-    return this.folderService.findOneByIds(id, user.id);
+    return this.folderService.findOneByFolderAndUserId(id, user.id);
   }
 
-  @UseGuards(JwtAuthGuard)
   @Patch()
   update(
     @AuthUser() user: IUserResponse,
     @Body() updateFoldertDto: UpdateFolderDto,
   ) {
-    return this.folderService.update(updateFoldertDto, user.id);
+    return this.folderService.updateByUser(updateFoldertDto, user.id);
   }
 
-  @UseGuards(JwtAuthGuard)
   @Delete('/:id')
   delete(@AuthUser() user: IUserResponse, @Param('id') id: string) {
-    return this.folderService.delete(id, user.id);
+    return this.folderService.deleteByUser(id, user.id);
   }
 }


### PR DESCRIPTION
### Summary

The folder module is separated to search by:
User `[/folder]`
- `AuthUser` is added in the controller to validate in the service that the folders belong to the user,
- Add in the repository to search using `folderId` and `userId`

Team `[/team/:teamId/folder]`
- `AuthTeamGuard` is added to verify that the user is a member of the team.
- `AdminRoleGuard` is added to verify that the user is admin or heigher to create, update and delete folders.
- Added in the repository to search using `folderId` and `teamId`

### Details

- Add folder.controller to team and user
- Add folder.service for team and user
- Add find one folder by user and team in repository
- Add test to find all folders by collection id
- Add test to new folder-team.controller
