### PR TITLE
Feat: Add CRUD environment to user and team 

### DIFF
--- a/src/modules/collection/application/service/collection.service.ts
+++ b/src/modules/collection/application/service/collection.service.ts
@@ -105,7 +105,7 @@ export class CollectionService {
     return this.collectionMapper.fromEntityToDto(collection);
   }
 
-  async findEnvironmentsByCollectionUserId(
+  async findEnvironmentsByCollectionAndUserId(
     collectionId: string,
     userId: string,
   ): Promise<EnviromentResponseDto[]> {
@@ -121,7 +121,7 @@ export class CollectionService {
     return collection.enviroments;
   }
 
-  async findEnvironmentsByCollectionTeamId(
+  async findEnvironmentsByCollectionAndTeamId(
     collectionId: string,
     teamId: string,
   ): Promise<EnviromentResponseDto[]> {
@@ -201,20 +201,24 @@ export class CollectionService {
     }
   }
 
-  async createAllEnvironments(
+  async createAllEnvironmentsByUser(
     collectionId: string,
     createEnvironmentsDto: CreateEnvironmentsDto[],
     userId: string,
   ): Promise<EnviromentResponseDto[]> {
-    const collection = await this.findOneByCollectionAndUserId(
+    await this.findOneByCollectionAndUserId(collectionId, userId);
+    return await this.environmentService.createAll(
+      createEnvironmentsDto,
       collectionId,
-      userId,
     );
-    if (!collection) {
-      throw new NotFoundException(
-        COLLECTION_RESPONSE.COLLECTION_NOT_FOUND_BY_USER_AND_ID,
-      );
-    }
+  }
+
+  async createAllEnvironmentsByTeam(
+    collectionId: string,
+    createEnvironmentsDto: CreateEnvironmentsDto[],
+    teamId: string,
+  ): Promise<EnviromentResponseDto[]> {
+    await this.findOneByCollectionAndTeamId(collectionId, teamId);
     return await this.environmentService.createAll(
       createEnvironmentsDto,
       collectionId,
@@ -313,13 +317,38 @@ export class CollectionService {
     return collectionDeleted;
   }
 
-  async deleteAllEnvironments(collectionId: string): Promise<boolean> {
-    const collection = await this.collectionRepository.findOne(collectionId);
+  async deleteAllEnvironmentsByUser(
+    collectionId: string,
+    userId: string,
+  ): Promise<boolean> {
+    const collection =
+      await this.collectionRepository.findOneByCollectionAndUserId(
+        collectionId,
+        userId,
+      );
+
     if (!collection) {
       throw new NotFoundException(
-        COLLECTION_RESPONSE.COLLECTION_NOT_FOUND_BY_ID,
+        COLLECTION_RESPONSE.COLLECTION_NOT_FOUND_BY_USER_AND_ID,
       );
     }
+
+    return await this.environmentService.deleteAll(collection.enviroments);
+  }
+
+  async deleteAllEnvironmentsByTeam(collectionId: string, teamId: string) {
+    const collection =
+      await this.collectionRepository.findOneByCollectionAndTeamId(
+        collectionId,
+        teamId,
+      );
+
+    if (!collection) {
+      throw new NotFoundException(
+        COLLECTION_RESPONSE.COLLECTION_NOT_FOUND_BY_TEAM,
+      );
+    }
+
     return await this.environmentService.deleteAll(collection.enviroments);
   }
 }

--- a/src/modules/collection/interface/__test__/collection.e2e.spec.ts
+++ b/src/modules/collection/interface/__test__/collection.e2e.spec.ts
@@ -11,6 +11,7 @@ import { COGNITO_SERVICE } from '@/modules/auth/application/repository/cognito.i
 import { JwtAuthGuard } from '@/modules/auth/infrastructure/guard/policy-auth.guard';
 import { JwtStrategy } from '@/modules/auth/infrastructure/jwt/jwt.strategy';
 import { ENVIROMENT_RESPONSE } from '@/modules/enviroment/application/exceptions/enviroment-response.enum';
+import { TEAM_RESPONSE } from '@/modules/team/application/exceptions/team-response.enum';
 
 import { COLLECTION_RESPONSE } from '../../application/exceptions/collection-response.enum';
 
@@ -242,6 +243,13 @@ describe('Collection - [/collection]', () => {
 
   describe('Delete one  - [DELETE /collection/:id]', () => {
     const collectionId = 'collection0';
+    it('should delete all environments associated with a collection', async () => {
+      const response = await request(app.getHttpServer())
+        .delete(`/collection/${collectionId}/environments`)
+        .expect(HttpStatus.OK);
+
+      expect(response.body).toEqual({});
+    });
     it('should delete one collection associated with a user', async () => {
       const response = await request(app.getHttpServer())
         .delete(`/collection/${collectionId}`)
@@ -260,14 +268,7 @@ describe('Collection - [/collection]', () => {
       );
     });
   });
-  it('should delete all environments associated with a collection', async () => {
-    const collectionId = 'collection1';
-    const response = await request(app.getHttpServer())
-      .delete(`/collection/${collectionId}/environments`)
-      .expect(HttpStatus.OK);
 
-    expect(response.body).toEqual({});
-  });
   describe('by Team - [/team/:teamId/collection]', () => {
     const team0Route = '/team/team0';
     describe('Create one  - [POST /collection]', () => {
@@ -284,6 +285,66 @@ describe('Collection - [/collection]', () => {
           name: 'team test',
           id: expect.any(String),
         });
+      });
+    });
+    describe('Create all - [POST /collection/:id]', () => {
+      const environments = [
+        {
+          name: 'inc4',
+          value: '4',
+        },
+        {
+          name: 'inc5',
+          value: '5',
+        },
+        {
+          name: 'inc6',
+          value: '6',
+        },
+      ];
+      it('Should save many environments at once', async () => {
+        const response = await request(app.getHttpServer())
+          .post(`${team0Route}/collection/collection3/environments`)
+          .send(environments)
+          .expect(HttpStatus.CREATED);
+
+        expect(response.body).toEqual([
+          {
+            name: 'inc4',
+            value: '4',
+            id: expect.any(String),
+          },
+          {
+            name: 'inc5',
+            value: '5',
+            id: expect.any(String),
+          },
+          {
+            name: 'inc6',
+            value: '6',
+            id: expect.any(String),
+          },
+        ]);
+      });
+      it('Should throw error when save many environments at once not associated with a collection', async () => {
+        const response = await request(app.getHttpServer())
+          .post(`${team0Route}/collection/collection2/environments`)
+          .send(environments)
+          .expect(HttpStatus.NOT_FOUND);
+
+        expect(response.body.message).toEqual(
+          COLLECTION_RESPONSE.COLLECTION_NOT_FOUND_BY_TEAM,
+        );
+      });
+      it('Should throw an unauthorize error when save many environments with a user without the required role', async () => {
+        const response = await request(app.getHttpServer())
+          .post(`/team/team1/collection/collection2/environments`)
+          .send(environments)
+          .expect(HttpStatus.UNAUTHORIZED);
+
+        expect(response.body.message).toEqual(
+          AUTH_RESPONSE.USER_ROLE_NOT_AUTHORIZED,
+        );
       });
     });
     describe('Get all - [GET - /collection]', () => {
@@ -306,6 +367,44 @@ describe('Collection - [/collection]', () => {
 
         expect(response.body.message).toEqual(
           AUTH_RESPONSE.USER_NOT_MEMBER_TEAM,
+        );
+      });
+      it('should get enviroments by collections id', async () => {
+        const response = await request(app.getHttpServer())
+          .get(`${team0Route}/collection/collection3/environments`)
+          .expect(HttpStatus.OK);
+
+        expect(response.body).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              id: expect.any(String),
+              name: expect.any(String),
+            }),
+          ]),
+        );
+      });
+      it('should get environment by collections id and environment name', async () => {
+        const response = await request(app.getHttpServer())
+          .get(`${team0Route}/collection/collection3/environment`)
+          .query({ name: 'enviroment2' })
+          .expect(HttpStatus.OK);
+
+        expect(response.body).toEqual(
+          expect.objectContaining({
+            id: expect.any(String),
+            name: 'enviroment2',
+            value: expect.any(String),
+          }),
+        );
+      });
+      it('should throw error when try to get environment that not exists', async () => {
+        const response = await request(app.getHttpServer())
+          .get('/collection/collection0/environment')
+          .query({ name: 'enviroment' })
+          .expect(HttpStatus.NOT_FOUND);
+
+        expect(response.body.message).toEqual(
+          ENVIROMENT_RESPONSE.ENVIRONMENT_EXISTS,
         );
       });
     });
@@ -358,6 +457,13 @@ describe('Collection - [/collection]', () => {
       });
     });
     describe('Delete one - [Delete /:id]', () => {
+      it('should delete all envionments associated with a collection', async () => {
+        const response = await request(app.getHttpServer())
+          .delete(`${team0Route}/collection/collection3/environments`)
+          .expect(HttpStatus.OK);
+
+        expect(response.body).toEqual({});
+      });
       it('should delete one collection associated with a team', async () => {
         const response = await request(app.getHttpServer())
           .delete(`${team0Route}/collection/collection3`)
@@ -367,11 +473,29 @@ describe('Collection - [/collection]', () => {
       });
       it('should throw error when try to delete one collection not associated with a team', async () => {
         const response = await request(app.getHttpServer())
-          .delete('/team/team1/collection/collection3')
+          .delete('/team/team/collection/collection3')
           .expect(HttpStatus.NOT_FOUND);
 
         expect(response.body.message).toEqual(
-          COLLECTION_RESPONSE.COLLECTION_NOT_FOUND_BY_ID,
+          TEAM_RESPONSE.TEAM_NOT_FOUND_BY_ID,
+        );
+      });
+      it('should throw error when delete all envionments not associated with a collection', async () => {
+        const response = await request(app.getHttpServer())
+          .delete('/team/team0/collection/collection2/environments')
+          .expect(HttpStatus.NOT_FOUND);
+
+        expect(response.body.message).toEqual(
+          COLLECTION_RESPONSE.COLLECTION_NOT_FOUND_BY_TEAM,
+        );
+      });
+      it('should throw error when try to delete one collection with a user without the required role', async () => {
+        const response = await request(app.getHttpServer())
+          .delete('/team/team1/collection/collection3')
+          .expect(HttpStatus.UNAUTHORIZED);
+
+        expect(response.body.message).toEqual(
+          AUTH_RESPONSE.USER_ROLE_NOT_AUTHORIZED,
         );
       });
     });

--- a/src/modules/collection/interface/__test__/fixture/Collection.yml
+++ b/src/modules/collection/interface/__test__/fixture/Collection.yml
@@ -19,3 +19,8 @@ items:
     id: 'collection3'
     name: 'collection3'
     teamId: '@team0'
+
+  collection4:
+    id: 'collection4'
+    name: 'collection4'
+    teamId: '@team2'

--- a/src/modules/collection/interface/__test__/fixture/Enviroment.yml
+++ b/src/modules/collection/interface/__test__/fixture/Enviroment.yml
@@ -4,12 +4,28 @@ items:
     id: 'enviroment0'
     name: 'enviroment0'
     value: 'enviroment0'
-    user: '@user0'
     collection: '@collection0'
 
   enviroment1:
     id: 'enviroment1'
     name: 'enviroment1'
     value: 'enviroment1'
-    user: '@user1'
     collection: '@collection1'
+
+  enviroment2:
+    id: 'enviroment2'
+    name: 'enviroment2'
+    value: 'enviroment2'
+    collection: '@collection3'
+
+  enviroment3:
+    id: 'enviroment3'
+    name: 'enviroment3'
+    value: 'enviroment3'
+    collection: '@collection2'
+
+  enviroment4:
+    id: 'enviroment4'
+    name: 'enviroment4'
+    value: 'enviroment4'
+    collection: '@collection3'

--- a/src/modules/collection/interface/__test__/fixture/Role.yml
+++ b/src/modules/collection/interface/__test__/fixture/Role.yml
@@ -16,4 +16,4 @@ items:
     id: 'role2'
     teamId: '@team1'
     userId: '@user0'
-    role: 'ADMIN'
+    role: 'USER'

--- a/src/modules/collection/interface/collection-team.controller.ts
+++ b/src/modules/collection/interface/collection-team.controller.ts
@@ -5,6 +5,7 @@ import {
   Get,
   Param,
   Patch,
+  Post,
   Query,
   UseGuards,
 } from '@nestjs/common';
@@ -12,6 +13,7 @@ import {
 import { AdminRoleGuard } from '@/modules/auth/infrastructure/guard/admin-role.guard';
 import { AuthTeamGuard } from '@/modules/auth/infrastructure/guard/auth-team.guard';
 import { JwtAuthGuard } from '@/modules/auth/infrastructure/guard/policy-auth.guard';
+import { CreateEnvironmentsDto } from '@/modules/enviroment/application/dto/create-all-environments.dto';
 import { EnviromentResponseDto } from '@/modules/enviroment/application/dto/enviroment-response.dto';
 import { FolderResponseDto } from '@/modules/folder/application/dto/folder-response.dto';
 
@@ -23,6 +25,20 @@ import { CollectionService } from '../application/service/collection.service';
 @UseGuards(JwtAuthGuard, AuthTeamGuard)
 export class CollectionTeamController {
   constructor(private readonly collectionService: CollectionService) {}
+
+  @UseGuards(AdminRoleGuard)
+  @Post('/:id/environments')
+  async createAllEnvironments(
+    @Body() createEnvironmentsDto: CreateEnvironmentsDto[],
+    @Param('id') id: string,
+    @Param('teamId') teamId: string,
+  ): Promise<EnviromentResponseDto[]> {
+    return this.collectionService.createAllEnvironmentsByTeam(
+      id,
+      createEnvironmentsDto,
+      teamId,
+    );
+  }
 
   @Get('/')
   async findCollectionsByTeam(@Param('teamId') teamId: string) {
@@ -50,7 +66,7 @@ export class CollectionTeamController {
     @Param('teamId') teamId: string,
     @Param('id') id: string,
   ): Promise<EnviromentResponseDto[]> {
-    return this.collectionService.findEnvironmentsByCollectionTeamId(
+    return this.collectionService.findEnvironmentsByCollectionAndTeamId(
       id,
       teamId,
     );
@@ -84,7 +100,7 @@ export class CollectionTeamController {
 
   @UseGuards(AdminRoleGuard)
   @Delete('/:id/environments')
-  async deleteAll(@Param('id') id: string) {
-    return this.collectionService.deleteAllEnvironments(id);
+  async deleteAll(@Param('teamId') teamId: string, @Param('id') id: string) {
+    return this.collectionService.deleteAllEnvironmentsByTeam(id, teamId);
   }
 }

--- a/src/modules/collection/interface/collection.controller.ts
+++ b/src/modules/collection/interface/collection.controller.ts
@@ -43,7 +43,7 @@ export class CollectionController {
     @Param('id') id: string,
     @AuthUser() user: IUserResponse,
   ): Promise<EnviromentResponseDto[]> {
-    return this.collectionService.createAllEnvironments(
+    return this.collectionService.createAllEnvironmentsByUser(
       id,
       createEnvironmentsDto,
       user.id,
@@ -78,7 +78,7 @@ export class CollectionController {
     @AuthUser() user: IUserResponse,
     @Param('id') id: string,
   ): Promise<EnviromentResponseDto[]> {
-    return this.collectionService.findEnvironmentsByCollectionUserId(
+    return this.collectionService.findEnvironmentsByCollectionAndUserId(
       id,
       user.id,
     );
@@ -109,7 +109,7 @@ export class CollectionController {
   }
 
   @Delete('/:id/environments')
-  async deleteAll(@Param('id') id: string) {
-    return this.collectionService.deleteAllEnvironments(id);
+  async deleteAll(@AuthUser() user: IUserResponse, @Param('id') id: string) {
+    return this.collectionService.deleteAllEnvironmentsByUser(id, user.id);
   }
 }

--- a/src/modules/enviroment/application/exceptions/enviroment-response.enum.ts
+++ b/src/modules/enviroment/application/exceptions/enviroment-response.enum.ts
@@ -1,7 +1,8 @@
 export enum ENVIROMENT_RESPONSE {
   ENVIRONMENT_NOT_FOUND = 'Variable not found',
   ENVIROMENT_NOT_FOUND_BY_COLLECTION_AND_USER = 'The user of the collection and the logged in user do not match',
-  ENVIROMENT_NOT_FOUND_BY_USER_ID = 'The user id does not match',
+  ENVIROMENT_NOT_FOUND_BY_USER_ID = 'Variable not found by user id',
+  ENVIROMENT_NOT_FOUND_BY_TEAM_ID = 'Variable not found team id',
   ENVIROMENT_COLLECTION_NOT_FOUND = 'The collection does not exist',
   ENVIROMENT_FAILED_SAVE = 'Could not save variable, please try again',
   ENVIROMENT_FAILED_DELETED = 'Could not deleted variable, please try again',

--- a/src/modules/enviroment/application/repository/enviroment.repository.ts
+++ b/src/modules/enviroment/application/repository/enviroment.repository.ts
@@ -5,8 +5,8 @@ import { IBaseRepository } from '@/common/application/base.repository';
 import { Enviroment } from '../../domain/enviroment.domain';
 
 export interface IEnviromentRepository extends IBaseRepository<Enviroment> {
-  findAll(userId: string): Promise<Enviroment[]>;
-  findOneByIds(id: string, userId: string): Promise<Enviroment>;
+  findOneByEnvAndUserId(id: string, userId: string): Promise<Enviroment>;
+  findOneByEnvAndTeamId(id: string, teamId: string): Promise<Enviroment>;
   findOneByName(name: string, collectionId: string): Promise<Enviroment>;
   findByNames(names: string[], collectionId: string): Promise<Enviroment[]>;
   update(enviroment: Enviroment): Promise<Enviroment>;

--- a/src/modules/enviroment/enviroment.module.ts
+++ b/src/modules/enviroment/enviroment.module.ts
@@ -2,19 +2,22 @@ import { Module, forwardRef } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { CollectionModule } from '../collection/collection.module';
+import { TeamModule } from '../team/team.module';
 import { EnviromentMapper } from './application/mapper/enviroment.mapper';
 import { ENVIROMENT_REPOSITORY } from './application/repository/enviroment.repository';
 import { EnviromentService } from './application/service/enviroment.service';
 import { EnviromentSchema } from './infrastructure/persistence/enviroment.schema';
 import { EnviromentRepository } from './infrastructure/persistence/enviroment.typeorm.repository';
-import { EnviromentController } from './interface/enviroment.controller';
+import { EnviromentUserController } from './interface/enviroment.controller';
+import { EnviromentTeamController } from './interface/environment-team.controller';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([EnviromentSchema]),
     forwardRef(() => CollectionModule),
+    TeamModule,
   ],
-  controllers: [EnviromentController],
+  controllers: [EnviromentUserController, EnviromentTeamController],
   providers: [
     EnviromentService,
     EnviromentMapper,

--- a/src/modules/enviroment/infrastructure/persistence/enviroment.typeorm.repository.ts
+++ b/src/modules/enviroment/infrastructure/persistence/enviroment.typeorm.repository.ts
@@ -21,14 +21,6 @@ export class EnviromentRepository implements IEnviromentRepository {
     return this.repository.save(environment);
   }
 
-  async findAll(collectionId: string): Promise<Enviroment[]> {
-    return await this.repository.find({
-      where: {
-        collectionId,
-      },
-    });
-  }
-
   async findOne(id: string): Promise<Enviroment> {
     return await this.repository.findOne({
       where: {
@@ -46,11 +38,20 @@ export class EnviromentRepository implements IEnviromentRepository {
     });
   }
 
-  async findOneByIds(id: string, collectionId: string): Promise<Enviroment> {
+  async findOneByEnvAndUserId(id: string, userId: string): Promise<Enviroment> {
     return await this.repository.findOne({
       where: {
         id,
-        collectionId,
+        collection: { userId },
+      },
+    });
+  }
+
+  async findOneByEnvAndTeamId(id: string, teamId: string): Promise<Enviroment> {
+    return await this.repository.findOne({
+      where: {
+        id,
+        collection: { teamId },
       },
     });
   }

--- a/src/modules/enviroment/interface/__test__/enviroment.e2e.spec.ts
+++ b/src/modules/enviroment/interface/__test__/enviroment.e2e.spec.ts
@@ -6,6 +6,7 @@ import * as request from 'supertest';
 import { loadFixtures } from '@data/util/loader';
 
 import { AppModule } from '@/app.module';
+import { AUTH_RESPONSE } from '@/modules/auth/application/exceptions/auth-error';
 import { COGNITO_SERVICE } from '@/modules/auth/application/repository/cognito.interface.service';
 import { JwtAuthGuard } from '@/modules/auth/infrastructure/guard/policy-auth.guard';
 import { JwtStrategy } from '@/modules/auth/infrastructure/jwt/jwt.strategy';
@@ -87,7 +88,7 @@ describe('Environment - [/environment]', () => {
         .expect(HttpStatus.NOT_FOUND);
 
       expect(response.body.message).toEqual(
-        COLLECTION_RESPONSE.COLLECTION_NOT_FOUND_BY_ID,
+        COLLECTION_RESPONSE.COLLECTION_NOT_FOUND_BY_USER_AND_ID,
       );
     });
     it('should update value of an environment if it already exists with the same name', async () => {
@@ -122,7 +123,7 @@ describe('Environment - [/environment]', () => {
         .expect(HttpStatus.NOT_FOUND);
 
       expect(response.body.message).toEqual(
-        ENVIROMENT_RESPONSE.ENVIRONMENT_NOT_FOUND,
+        ENVIROMENT_RESPONSE.ENVIROMENT_NOT_FOUND_BY_USER_ID,
       );
     });
   });
@@ -153,7 +154,7 @@ describe('Environment - [/environment]', () => {
         .expect(HttpStatus.NOT_FOUND);
 
       expect(response.body.message).toEqual(
-        ENVIROMENT_RESPONSE.ENVIRONMENT_NOT_FOUND,
+        ENVIROMENT_RESPONSE.ENVIROMENT_NOT_FOUND_BY_USER_ID,
       );
     });
   });
@@ -185,8 +186,166 @@ describe('Environment - [/environment]', () => {
         .expect(HttpStatus.NOT_FOUND);
 
       expect(response.body.message).toEqual(
-        ENVIROMENT_RESPONSE.ENVIRONMENT_NOT_FOUND,
+        ENVIROMENT_RESPONSE.ENVIROMENT_NOT_FOUND_BY_USER_ID,
       );
+    });
+  });
+  describe('By Team - [/team/:teamId/environment]', () => {
+    const validTeamRoute = '/team/team0';
+    const invalidTeamRoute = '/team/team1';
+    const unauthorizeRoute = '/team/team2';
+
+    describe('Create one - [POST /environment]', () => {
+      const enviromentDto = {
+        name: 'test',
+        value: 'test',
+      };
+      it('should create a new environment by team id', async () => {
+        const response = await request(app.getHttpServer())
+          .post(`${validTeamRoute}/environment/`)
+          .send({ ...enviromentDto, collectionId: 'collection3' })
+          .expect(HttpStatus.CREATED);
+
+        expect(response.body).toEqual({
+          ...enviromentDto,
+          id: expect.any(String),
+        });
+      });
+      it('should throw error when try to create a new environment not associated with the team and collections', async () => {
+        const response = await request(app.getHttpServer())
+          .post(`${invalidTeamRoute}/environment/`)
+          .send({ ...enviromentDto, collectionId: 'collection' })
+          .expect(HttpStatus.NOT_FOUND);
+
+        expect(response.body.message).toEqual(
+          COLLECTION_RESPONSE.COLLECTION_NOT_FOUND_BY_TEAM,
+        );
+      });
+      it('should update value of an environment if it already exists with the same name', async () => {
+        const responseExpected = expect.objectContaining({
+          ...enviromentDto,
+          id: expect.any(String),
+        });
+        const response = await request(app.getHttpServer())
+          .post(`${validTeamRoute}/environment/`)
+          .send({ ...enviromentDto, collectionId: 'collection3' })
+          .expect(HttpStatus.CREATED);
+
+        expect(response.body).toEqual(responseExpected);
+      });
+      it('should throw error when try to create one environment with a user without the required role', async () => {
+        const response = await request(app.getHttpServer())
+          .post(`${unauthorizeRoute}/environment/`)
+          .send({ ...enviromentDto, collectionId: 'collection2' })
+          .expect(HttpStatus.UNAUTHORIZED);
+
+        expect(response.body.message).toEqual(
+          AUTH_RESPONSE.USER_ROLE_NOT_AUTHORIZED,
+        );
+      });
+    });
+    describe('Get one - [GET /environment/:id]', () => {
+      it('should get one environment associated with a collection and team', async () => {
+        const response = await request(app.getHttpServer())
+          .get(`${validTeamRoute}/environment/enviroment2`)
+          .expect(HttpStatus.OK);
+
+        expect(response.body).toEqual({
+          id: 'enviroment2',
+          name: 'enviroment2',
+          value: 'enviroment2',
+        });
+      });
+      it('should throw error when try to get one environment not associated with a team', async () => {
+        const response = await request(app.getHttpServer())
+          .get(`${invalidTeamRoute}/environment/enviroment3`)
+          .expect(HttpStatus.NOT_FOUND);
+
+        expect(response.body.message).toEqual(
+          ENVIROMENT_RESPONSE.ENVIROMENT_NOT_FOUND_BY_TEAM_ID,
+        );
+      });
+    });
+    describe('Update one  - [PUT /environment/:id]', () => {
+      it('should update one enviroment associated with a team', async () => {
+        const response = await request(app.getHttpServer())
+          .patch(`${validTeamRoute}/environment`)
+          .send({
+            name: 'enviroment updated',
+            id: 'enviroment2',
+          })
+          .expect(HttpStatus.OK);
+
+        expect(response.body).toEqual({
+          id: 'enviroment2',
+          name: 'enviroment updated',
+          value: 'enviroment2',
+        });
+      });
+      it('should throw error when try to update one environment not associated with a team', async () => {
+        const response = await request(app.getHttpServer())
+          .patch(`${invalidTeamRoute}/environment`)
+          .send({
+            name: 'enviroment updated',
+            id: 'enviroment3',
+          })
+          .expect(HttpStatus.NOT_FOUND);
+
+        expect(response.body.message).toEqual(
+          ENVIROMENT_RESPONSE.ENVIROMENT_NOT_FOUND_BY_TEAM_ID,
+        );
+      });
+      it('should throw error when try to update one environment with a user without the required role', async () => {
+        const response = await request(app.getHttpServer())
+          .patch(`${unauthorizeRoute}/environment`)
+          .send({
+            name: 'enviroment updated',
+            id: 'enviroment3',
+          })
+          .expect(HttpStatus.UNAUTHORIZED);
+
+        expect(response.body.message).toEqual(
+          AUTH_RESPONSE.USER_ROLE_NOT_AUTHORIZED,
+        );
+      });
+    });
+    describe('Delete one  - [DELETE /environment/:id]', () => {
+      it('should delete one environment associated with a team', async () => {
+        const response = await request(app.getHttpServer())
+          .delete(`${validTeamRoute}/environment/enviroment2`)
+          .expect(HttpStatus.OK);
+
+        expect(response.body).toEqual({});
+      });
+      it('should delete on environment searched by name and collection', async () => {
+        const response = await request(app.getHttpServer())
+          .delete(`${validTeamRoute}/environment/`)
+          .query({
+            name: 'enviroment4',
+            collectionId: 'collection3',
+          })
+          .expect(HttpStatus.OK);
+
+        expect(response.body).toEqual({});
+      });
+      it('should throw error when try to delete one environment not associated with a team', async () => {
+        const response = await request(app.getHttpServer())
+          .delete(`${invalidTeamRoute}/environment/enviroment3`)
+          .expect(HttpStatus.NOT_FOUND);
+
+        expect(response.body.message).toEqual(
+          ENVIROMENT_RESPONSE.ENVIROMENT_NOT_FOUND_BY_TEAM_ID,
+        );
+      });
+      it('should throw error when try to delete one environment with a user without the required role', async () => {
+        const response = await request(app.getHttpServer())
+          .delete(`${unauthorizeRoute}/environment/enviroment3`)
+          .expect(HttpStatus.UNAUTHORIZED);
+
+        expect(response.body.message).toEqual(
+          AUTH_RESPONSE.USER_ROLE_NOT_AUTHORIZED,
+        );
+      });
     });
   });
 });

--- a/src/modules/enviroment/interface/__test__/fixture/Collection.yml
+++ b/src/modules/enviroment/interface/__test__/fixture/Collection.yml
@@ -1,11 +1,21 @@
 entity: Collection
 items:
   collection0:
-    id: "collection0"
+    id: 'collection0'
     name: 'collection0'
     user: '@user0'
 
   collection1:
-    id: "collection1"
+    id: 'collection1'
     name: 'collection1'
     user: '@user1'
+
+  collection2:
+    id: 'collection2'
+    name: 'collection2'
+    teamId: '@team2'
+
+  collection3:
+    id: 'collection3'
+    name: 'collection3'
+    teamId: '@team0'

--- a/src/modules/enviroment/interface/__test__/fixture/Enviroment.yml
+++ b/src/modules/enviroment/interface/__test__/fixture/Enviroment.yml
@@ -4,12 +4,28 @@ items:
     id: 'enviroment0'
     name: 'enviroment0'
     value: 'enviroment0'
-    user: '@user0'
     collection: '@collection0'
 
   enviroment1:
     id: 'enviroment1'
     name: 'enviroment1'
     value: 'enviroment1'
-    user: '@user1'
     collection: '@collection1'
+
+  enviroment2:
+    id: 'enviroment2'
+    name: 'enviroment2'
+    value: 'enviroment2'
+    collection: '@collection3'
+
+  enviroment3:
+    id: 'enviroment3'
+    name: 'enviroment3'
+    value: 'enviroment3'
+    collection: '@collection2'
+
+  enviroment4:
+    id: 'enviroment4'
+    name: 'enviroment4'
+    value: 'enviroment4'
+    collection: '@collection3'

--- a/src/modules/enviroment/interface/__test__/fixture/Role.yml
+++ b/src/modules/enviroment/interface/__test__/fixture/Role.yml
@@ -1,0 +1,25 @@
+entity: UserRoleToTeam
+items:
+  role0:
+    id: 'role0'
+    teamId: '@team0'
+    userId: '@user0'
+    role: 'OWNER'
+
+  role1:
+    id: 'role1'
+    teamId: '@team1'
+    userId: '@user1'
+    role: 'OWNER'
+
+  role2:
+    id: 'role2'
+    teamId: '@team1'
+    userId: '@user0'
+    role: 'ADMIN'
+
+  role3:
+    id: 'role3'
+    teamId: '@team2'
+    userId: '@user0'
+    role: 'USER'

--- a/src/modules/enviroment/interface/__test__/fixture/Team.yml
+++ b/src/modules/enviroment/interface/__test__/fixture/Team.yml
@@ -1,0 +1,19 @@
+entity: Team
+items:
+  team0:
+    id: 'team0'
+    name: 'team0'
+    adminId: 'user0'
+    userMembers: []
+
+  team1:
+    id: 'team1'
+    name: 'team1'
+    adminId: 'user1'
+    userMembers: ['user0']
+
+  team2:
+    id: 'team2'
+    name: 'team2'
+    adminId: 'user1'
+    userMembers: ['']

--- a/src/modules/enviroment/interface/enviroment.controller.ts
+++ b/src/modules/enviroment/interface/enviroment.controller.ts
@@ -21,40 +21,36 @@ import { UpdateEnviromentDto } from '../application/dto/update-enviroment.dto';
 import { EnviromentService } from '../application/service/enviroment.service';
 
 @Controller('environment')
-export class EnviromentController {
+@UseGuards(JwtAuthGuard)
+export class EnviromentUserController {
   constructor(private readonly enviromentService: EnviromentService) {}
 
-  @UseGuards(JwtAuthGuard)
   @Post('')
-  async create(@Body() createEnviromentDto: CreateEnviromentDto) {
-    return this.enviromentService.create(createEnviromentDto);
+  async create(
+    @AuthUser() user: IUserResponse,
+    @Body() createEnviromentDto: CreateEnviromentDto,
+  ) {
+    return this.enviromentService.createByUser(createEnviromentDto, user.id);
   }
 
-  @UseGuards(JwtAuthGuard)
-  @Get('')
-  findAll(@AuthUser() user: IUserResponse) {
-    return this.enviromentService.findAll(user);
-  }
-
-  @UseGuards(JwtAuthGuard)
   @Get('/:id')
-  findOne(@Param('id') id: string) {
-    return this.enviromentService.findOne(id);
+  findOne(@AuthUser() user: IUserResponse, @Param('id') id: string) {
+    return this.enviromentService.findOneByEnvAndUserId(id, user.id);
   }
 
-  @UseGuards(JwtAuthGuard)
   @Patch()
-  update(@Body() updateEnviromentDto: UpdateEnviromentDto) {
-    return this.enviromentService.update(updateEnviromentDto);
+  update(
+    @AuthUser() user: IUserResponse,
+    @Body() updateEnviromentDto: UpdateEnviromentDto,
+  ) {
+    return this.enviromentService.updateByUser(updateEnviromentDto, user.id);
   }
 
-  @UseGuards(JwtAuthGuard)
   @Delete('/:id')
-  delete(@Param('id') id: string) {
-    return this.enviromentService.delete(id);
+  delete(@AuthUser() user: IUserResponse, @Param('id') id: string) {
+    return this.enviromentService.deleteByUser(id, user.id);
   }
 
-  @UseGuards(JwtAuthGuard)
   @Delete('/')
   deleteByName(
     @Query('name') name: string,

--- a/src/modules/enviroment/interface/environment-team.controller.ts
+++ b/src/modules/enviroment/interface/environment-team.controller.ts
@@ -1,0 +1,63 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+
+import { AdminRoleGuard } from '@/modules/auth/infrastructure/guard/admin-role.guard';
+import { AuthTeamGuard } from '@/modules/auth/infrastructure/guard/auth-team.guard';
+import { JwtAuthGuard } from '@/modules/auth/infrastructure/guard/policy-auth.guard';
+
+import { CreateEnviromentDto } from '../application/dto/create-enviroment.dto';
+import { UpdateEnviromentDto } from '../application/dto/update-enviroment.dto';
+import { EnviromentService } from '../application/service/enviroment.service';
+
+@Controller('/team/:teamId/environment')
+@UseGuards(JwtAuthGuard, AuthTeamGuard)
+export class EnviromentTeamController {
+  constructor(private readonly enviromentService: EnviromentService) {}
+
+  @UseGuards(AdminRoleGuard)
+  @Post('/')
+  async create(
+    @Param('teamId') teamId: string,
+    @Body() createEnviromentDto: CreateEnviromentDto,
+  ) {
+    return this.enviromentService.createByTeam(createEnviromentDto, teamId);
+  }
+
+  @Get('/:id')
+  findOne(@Param('teamId') teamId: string, @Param('id') id: string) {
+    return this.enviromentService.findOneByEnvAndTeamId(id, teamId);
+  }
+
+  @UseGuards(AdminRoleGuard)
+  @Patch('')
+  update(
+    @Param('teamId') teamId: string,
+    @Body() updateEnviromentDto: UpdateEnviromentDto,
+  ) {
+    return this.enviromentService.updateByTeam(updateEnviromentDto, teamId);
+  }
+
+  @UseGuards(AdminRoleGuard)
+  @Delete('/:id')
+  delete(@Param('teamId') teamId: string, @Param('id') id: string) {
+    return this.enviromentService.deleteByTeam(id, teamId);
+  }
+
+  @UseGuards(AdminRoleGuard)
+  @Delete('/')
+  deleteByName(
+    @Query('name') name: string,
+    @Query('collectionId') collectionId: string,
+  ) {
+    return this.enviromentService.deleteByName(name, collectionId);
+  }
+}


### PR DESCRIPTION
### Summary

Add find, create and delete all environments in collection module,
The environment module is separated to search by:
User `[/environment]`
- `AuthUser` is added in the controller to validate in the service that the environments belong to the user,
- Add in the repository to search using `environmentId` and `userId`

Team `[/team/:teamId/environment]`
- `AuthTeamGuard` is added to verify that the user is a member of the team.
- `AdminRoleGuard` is added to verify that the user is admin or heigher to create, update and delete environments.
- Added in the repository to search using `environmentId` and `teamId`

### Details

- Add environment.controller by team or user
- Add environment.service for team and user
- Add find one environment by user and team in repository
- Add find, get and delete all environments by collection id
- Add test to find, get and delete all environments by collection
- Add test to new environment-team.controller
