### PR TITLE
Feat: Add CRUD invocation to user and team

### DIFF
--- a/src/modules/folder/application/service/folder.service.ts
+++ b/src/modules/folder/application/service/folder.service.ts
@@ -103,6 +103,28 @@ export class FolderService {
     return this.folderMapper.fromEntityToDto(folder);
   }
 
+  async findAllInvocationsByUser(folderId: string, userId: string) {
+    const folder = await this.folderRepository.findOneByFolderAndUserId(
+      folderId,
+      userId,
+    );
+    if (!folder) {
+      throw new NotFoundException(FOLDER_RESPONSE.FOLDER_NOT_FOUND_BY_USER_ID);
+    }
+    return folder.invocations;
+  }
+
+  async findAllInvocationsByTeam(folderId: string, teamId: string) {
+    const folder = await this.folderRepository.findOneByFolderAndTeamId(
+      folderId,
+      teamId,
+    );
+    if (!folder) {
+      throw new NotFoundException(FOLDER_RESPONSE.FOLDER_NOT_FOUND_BY_TEAM_ID);
+    }
+    return folder.invocations;
+  }
+
   async updateByUser(
     updateFolderDto: UpdateFolderDto,
     userId: string,

--- a/src/modules/folder/folder.module.ts
+++ b/src/modules/folder/folder.module.ts
@@ -29,6 +29,7 @@ import { FolderUserController } from './interface/folder.controller';
     },
   ],
   exports: [
+    FolderService,
     FolderMapper,
     {
       provide: FOLDER_REPOSITORY,

--- a/src/modules/folder/interface/__test__/fixture/Invocation.yml
+++ b/src/modules/folder/interface/__test__/fixture/Invocation.yml
@@ -1,0 +1,19 @@
+entity: Invocation
+items:
+  invocation0:
+    id: 'invocation0'
+    name: 'invocation0'
+    folder: '@folder0'
+    network: 'FUTURENET'
+
+  invocation1:
+    id: 'invocation1'
+    name: 'invocation1'
+    folder: '@folder0'
+    network: 'FUTURENET'
+
+  invocation2:
+    id: 'invocation2'
+    name: 'invocation2'
+    folder: '@folder2'
+    network: 'FUTURENET'

--- a/src/modules/folder/interface/__test__/folder.e2e.spec.ts
+++ b/src/modules/folder/interface/__test__/folder.e2e.spec.ts
@@ -123,7 +123,33 @@ describe('Folder - [/folder]', () => {
       );
     });
   });
+  describe('Get all invocations - [GET /folder/:id/invocations]', () => {
+    it('should get all invocations associated with a user', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/folder/folder0/invocations')
+        .expect(HttpStatus.OK);
 
+      expect(response.body).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: 'invocation0',
+            folderId: 'folder0',
+            network: 'FUTURENET',
+            id: 'invocation0',
+          }),
+        ]),
+      );
+    });
+    it('should throw error when try to get all invocations not associated with the user', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/folder/folder1/invocations')
+        .expect(HttpStatus.NOT_FOUND);
+
+      expect(response.body.message).toEqual(
+        FOLDER_RESPONSE.FOLDER_NOT_FOUND_BY_USER_ID,
+      );
+    });
+  });
   describe('Update one  - [PUT /folder/:id]', () => {
     it('should update one folder associated with a user', async () => {
       const response = await request(app.getHttpServer())
@@ -242,6 +268,33 @@ describe('Folder - [/folder]', () => {
       it('should throw error when try to get one folder not associated with a team', async () => {
         const response = await request(app.getHttpServer())
           .get(`${invalidRoute}/folder1`)
+          .expect(HttpStatus.NOT_FOUND);
+
+        expect(response.body.message).toEqual(
+          FOLDER_RESPONSE.FOLDER_NOT_FOUND_BY_TEAM_ID,
+        );
+      });
+    });
+    describe('Get all invocations - [GET /folder/:id/invocations]', () => {
+      it('should get all invocations associated with a team', async () => {
+        const response = await request(app.getHttpServer())
+          .get(`${validRoute}/folder2/invocations`)
+          .expect(HttpStatus.OK);
+
+        expect(response.body).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              name: 'invocation2',
+              folderId: 'folder2',
+              network: 'FUTURENET',
+              id: 'invocation2',
+            }),
+          ]),
+        );
+      });
+      it('should throw error when try to get all invocations not associated with the team', async () => {
+        const response = await request(app.getHttpServer())
+          .get(`${validRoute}/folder/invocations`)
           .expect(HttpStatus.NOT_FOUND);
 
         expect(response.body.message).toEqual(

--- a/src/modules/folder/interface/folder-team.controller.ts
+++ b/src/modules/folder/interface/folder-team.controller.ts
@@ -36,6 +36,11 @@ export class FolderTeamController {
     return this.folderService.findOneByFolderAndTeamId(id, teamId);
   }
 
+  @Get('/:id/invocations')
+  findAllInvocations(@Param('teamId') teamId: string, @Param('id') id: string) {
+    return this.folderService.findAllInvocationsByTeam(id, teamId);
+  }
+
   @UseGuards(AdminRoleGuard)
   @Patch('')
   update(

--- a/src/modules/folder/interface/folder.controller.ts
+++ b/src/modules/folder/interface/folder.controller.ts
@@ -37,6 +37,11 @@ export class FolderUserController {
     return this.folderService.findOneByFolderAndUserId(id, user.id);
   }
 
+  @Get('/:id/invocations')
+  findAllInvocations(@AuthUser() user: IUserResponse, @Param('id') id: string) {
+    return this.folderService.findAllInvocationsByUser(id, user.id);
+  }
+
   @Patch()
   update(
     @AuthUser() user: IUserResponse,

--- a/src/modules/invocation/application/exceptions/invocation-response.enum.dto.ts
+++ b/src/modules/invocation/application/exceptions/invocation-response.enum.dto.ts
@@ -3,6 +3,7 @@ export enum INVOCATION_RESPONSE {
   Invocation_NOT_FOUND_BY_ID = 'Invocation with specified ID not found',
   Invocation_NOT_FOUND_BY_USER = 'No invocations found for user',
   Invocation_NOT_FOUND_BY_USER_AND_ID = 'No invocations found for user with specified ID',
+  Invocation_NOT_FOUND_BY_TEAM_AND_ID = 'No invocations found for team with specified ID',
   Invocation_NOT_SAVE = 'Unable to save invocation',
   Invocation_NOT_DELETED = 'Unable to delete invocation',
   Invocation_NOT_UPDATED = 'Unable to update invocation',

--- a/src/modules/invocation/infrastructure/persistence/invocation.typeorm.repository.ts
+++ b/src/modules/invocation/infrastructure/persistence/invocation.typeorm.repository.ts
@@ -35,7 +35,9 @@ export class InvocationRepository implements IInvocationRepository {
   async findOne(id: string): Promise<Invocation> {
     return await this.repository.findOne({
       relations: {
-        folder: true,
+        folder: {
+          collection: true,
+        },
         selectedMethod: true,
         methods: true,
       },

--- a/src/modules/invocation/interface/__test__/fixture/Collection.yml
+++ b/src/modules/invocation/interface/__test__/fixture/Collection.yml
@@ -9,3 +9,18 @@ items:
     id: 'collection1'
     name: 'collection1'
     user: '@user1'
+
+  collection2:
+    id: 'collection2'
+    name: 'collection2'
+    teamId: '@team0'
+
+  collection3:
+    id: 'collection3'
+    name: 'collection3'
+    teamId: '@team1'
+
+  collection4:
+    id: 'collection4'
+    name: 'collection4'
+    teamId: '@team2'

--- a/src/modules/invocation/interface/__test__/fixture/Folder.yml
+++ b/src/modules/invocation/interface/__test__/fixture/Folder.yml
@@ -3,11 +3,24 @@ items:
   folder0:
     id: 'folder0'
     name: 'folder0'
-    user: '@user0'
     collection: '@collection0'
 
   folder1:
     id: 'folder1'
     name: 'folder1'
-    user: '@user1'
     collection: '@collection1'
+
+  folder2:
+    id: 'folder2'
+    name: 'folder2'
+    collection: '@collection2'
+
+  folder3:
+    id: 'folder3'
+    name: 'folder3'
+    collection: '@collection3'
+
+  folder4:
+    id: 'folder4'
+    name: 'folder4'
+    collection: '@collection4'

--- a/src/modules/invocation/interface/__test__/fixture/Invocation.yml
+++ b/src/modules/invocation/interface/__test__/fixture/Invocation.yml
@@ -3,21 +3,18 @@ items:
   invocation0:
     id: 'invocation0'
     name: 'invocation0'
-    user: '@user0'
     folder: '@folder0'
     network: 'FUTURENET'
 
   invocation1:
     id: 'invocation1'
     name: 'invocation1'
-    user: '@user1'
     folder: '@folder1'
     network: 'FUTURENET'
 
   invocation2:
     id: 'invocation2'
     name: 'invocation2'
-    user: '@user0'
     folder: '@folder0'
     network: 'FUTURENET'
     publicKey: 'publicKey2'
@@ -25,7 +22,6 @@ items:
   invocation3:
     id: 'invocation3'
     name: 'invocation3'
-    user: '@user0'
     folder: '@folder1'
     network: 'FUTURENET'
     publicKey: 'publicKey3'
@@ -36,15 +32,60 @@ items:
   invocation4:
     id: 'invocation4'
     name: 'invocation4'
-    user: '@user0'
     folder: '@folder0'
     network: 'FUTURENET'
 
   invocation5:
     id: 'invocation5'
     name: 'invocation5'
-    user: '@user0'
-    folder: '@folder1'
+    folder: '@folder0'
+    network: 'FUTURENET'
+    contractId: 'contractId'
+    publicKey: 'publicKey5'
+    secretKey: 'secretKey5'
+    preInvocation: 'const a = () => "a"; a();'
+    postInvocation: 'const a = () => "a"; a();'
+    selectedMethod: '@method4'
+
+  invocation6:
+    id: 'invocation6'
+    name: 'invocation6'
+    folder: '@folder2'
+    network: 'FUTURENET'
+
+  invocation7:
+    id: 'invocation7'
+    name: 'invocation7'
+    folder: '@folder4'
+    network: 'FUTURENET'
+
+  invocation8:
+    id: 'invocation8'
+    name: 'invocation8'
+    folder: '@folder2'
+    network: 'FUTURENET'
+    publicKey: 'publicKey2'
+
+  invocation9:
+    id: 'invocation9'
+    name: 'invocation9'
+    folder: '@folder3'
+    network: 'FUTURENET'
+    publicKey: 'publicKey3'
+    secretKey: 'secretKey3'
+    preInvocation: 'a'
+    selectedMethod: '@method3'
+
+  invocation10:
+    id: 'invocation10'
+    name: 'invocation10'
+    folder: '@folder2'
+    network: 'FUTURENET'
+
+  invocation11:
+    id: 'invocation11'
+    name: 'invocation11'
+    folder: '@folder2'
     network: 'FUTURENET'
     contractId: 'contractId'
     publicKey: 'publicKey5'

--- a/src/modules/invocation/interface/__test__/fixture/Method.yml
+++ b/src/modules/invocation/interface/__test__/fixture/Method.yml
@@ -43,9 +43,54 @@ items:
   method4:
     id: 'method4'
     name: 'method4'
-    inputs: [{name: 'name', type: 'string'}]
+    inputs: [{ name: 'name', type: 'string' }]
     outputs: []
     params: [{ name: 'name', value: 'string' }]
     docs: 'docs1'
     user: '@user0'
     invocation: '@invocation2'
+
+  method5:
+    id: 'method5'
+    name: 'method5'
+    inputs: []
+    outputs: []
+    params: []
+    docs: 'docs0'
+    invocation: '@invocation6'
+
+  method6:
+    id: 'method6'
+    name: 'method6'
+    inputs: []
+    outputs: []
+    params: []
+    docs: 'docs1'
+    invocation: '@invocation7'
+
+  method7:
+    id: 'method7'
+    name: 'method7'
+    inputs: []
+    outputs: []
+    params: []
+    docs: 'docs0'
+    invocation: '@invocation6'
+
+  method8:
+    id: 'method8'
+    name: 'method8'
+    inputs: []
+    outputs: []
+    params: [{ name: 'name', value: 'value' }]
+    docs: 'docs1'
+    invocation: '@invocation11'
+
+  method9:
+    id: 'method9'
+    name: 'method9'
+    inputs: [{ name: 'name', type: 'string' }]
+    outputs: []
+    params: [{ name: 'name', value: 'string' }]
+    docs: 'docs1'
+    invocation: '@invocation11'

--- a/src/modules/invocation/interface/__test__/fixture/Role.yml
+++ b/src/modules/invocation/interface/__test__/fixture/Role.yml
@@ -1,0 +1,25 @@
+entity: UserRoleToTeam
+items:
+  role0:
+    id: 'role0'
+    teamId: '@team0'
+    userId: '@user0'
+    role: 'OWNER'
+
+  role1:
+    id: 'role1'
+    teamId: '@team1'
+    userId: '@user1'
+    role: 'OWNER'
+
+  role2:
+    id: 'role2'
+    teamId: '@team1'
+    userId: '@user0'
+    role: 'ADMIN'
+
+  role3:
+    id: 'role3'
+    teamId: '@team2'
+    userId: '@user0'
+    role: 'USER'

--- a/src/modules/invocation/interface/__test__/fixture/Team.yml
+++ b/src/modules/invocation/interface/__test__/fixture/Team.yml
@@ -1,0 +1,19 @@
+entity: Team
+items:
+  team0:
+    id: 'team0'
+    name: 'team0'
+    adminId: 'user0'
+    users: []
+
+  team1:
+    id: 'team1'
+    name: 'team1'
+    adminId: 'user1'
+    users: ['user0']
+
+  team2:
+    id: 'team2'
+    name: 'team2'
+    adminId: 'user1'
+    users: ['user0']

--- a/src/modules/invocation/interface/__test__/invocation.e2e.spec.ts
+++ b/src/modules/invocation/interface/__test__/invocation.e2e.spec.ts
@@ -7,9 +7,11 @@ import { loadFixtures } from '@data/util/loader';
 
 import { AppModule } from '@/app.module';
 import { CONTRACT_SERVICE } from '@/common/application/repository/contract.interface.service';
+import { AUTH_RESPONSE } from '@/modules/auth/application/exceptions/auth-error';
 import { COGNITO_SERVICE } from '@/modules/auth/application/repository/cognito.interface.service';
 import { JwtAuthGuard } from '@/modules/auth/infrastructure/guard/policy-auth.guard';
 import { JwtStrategy } from '@/modules/auth/infrastructure/jwt/jwt.strategy';
+import { FOLDER_RESPONSE } from '@/modules/folder/application/exceptions/folder-response.enum';
 
 import { INVOCATION_RESPONSE } from '../../application/exceptions/invocation-response.enum.dto';
 
@@ -74,6 +76,10 @@ describe('Invocation - [/invocation]', () => {
     await app.init();
   });
 
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   describe('Create one  - [POST /invocation]', () => {
     it('It should create a new invocation', async () => {
       const responseExpected = expect.objectContaining({
@@ -110,7 +116,7 @@ describe('Invocation - [/invocation]', () => {
         .expect(HttpStatus.NOT_FOUND);
 
       expect(response.body.message).toEqual(
-        INVOCATION_RESPONSE.INVOCATION_FOLDER_NOT_EXISTS,
+        FOLDER_RESPONSE.FOLDER_NOT_FOUND_BY_USER_ID,
       );
     });
   });
@@ -241,7 +247,7 @@ describe('Invocation - [/invocation]', () => {
         .expect(HttpStatus.NOT_FOUND);
 
       expect(response.body.message).toEqual(
-        INVOCATION_RESPONSE.Invocation_NOT_FOUND_BY_USER_AND_ID,
+        INVOCATION_RESPONSE.Invocation_NOT_FOUND,
       );
     });
     it('should throw error when try to update and invocation with an invalid contract id', async () => {
@@ -355,7 +361,7 @@ describe('Invocation - [/invocation]', () => {
         .expect(HttpStatus.NOT_FOUND);
 
       expect(response.body.message).toEqual(
-        INVOCATION_RESPONSE.Invocation_NOT_FOUND_BY_USER_AND_ID,
+        INVOCATION_RESPONSE.Invocation_NOT_FOUND,
       );
     });
     it('should change to TESTNET network', async () => {
@@ -447,6 +453,376 @@ describe('Invocation - [/invocation]', () => {
       expect(response.body.message).toEqual(
         INVOCATION_RESPONSE.INVOCATION_FAILED_TO_RUN_WITHOUT_KEYS_OR_SELECTED_METHOD,
       );
+    });
+  });
+  describe('By Team - [/team/:teamId/invocation]', () => {
+    const validRoute = '/team/team0/invocation';
+    const invalidRoute = '/team/team1/invocation';
+    const unauthorizeRoute = '/team/team2/invocation';
+
+    describe('Create one  - [POST /invocation]', () => {
+      it('should create a new invocation', async () => {
+        const responseExpected = expect.objectContaining({
+          id: expect.any(String),
+          name: expect.any(String),
+          secretKey: expect.any(String),
+          publicKey: expect.any(String),
+          contractId: expect.any(String),
+          network: expect.any(String),
+        });
+        const response = await request(app.getHttpServer())
+          .post(`${validRoute}`)
+          .send({
+            name: 'test',
+            folderId: 'folder2',
+            secretKey: 'test',
+            publicKey: 'test',
+            contractId: 'test contract',
+          })
+          .expect(HttpStatus.CREATED);
+
+        expect(response.body).toEqual(responseExpected);
+      });
+      it('should throw error when try to create a new invocation not associated with a team', async () => {
+        const response = await request(app.getHttpServer())
+          .post(`${invalidRoute}`)
+          .send({
+            name: 'test',
+            folderId: 'folder2',
+            secretKey: 'test',
+            publicKey: 'test',
+            contractId: 'test contract',
+          })
+          .expect(HttpStatus.NOT_FOUND);
+
+        expect(response.body.message).toEqual(
+          FOLDER_RESPONSE.FOLDER_NOT_FOUND_BY_TEAM_ID,
+        );
+      });
+      it('should throw an unauthorize error when try to create a new invocation with a user without the required role', async () => {
+        const response = await request(app.getHttpServer())
+          .post(`${unauthorizeRoute}`)
+          .send({
+            name: 'test',
+            folderId: 'folder2',
+            secretKey: 'test',
+            publicKey: 'test',
+            contractId: 'test contract',
+          })
+          .expect(HttpStatus.UNAUTHORIZED);
+
+        expect(response.body.message).toEqual(
+          AUTH_RESPONSE.USER_ROLE_NOT_AUTHORIZED,
+        );
+      });
+    });
+    describe('Get one  - [GET /invocation/:id]', () => {
+      it('should get one invocation associated with a team', async () => {
+        const responseExpected = expect.objectContaining({
+          id: 'invocation6',
+          name: expect.any(String),
+          secretKey: null,
+          publicKey: null,
+          contractId: null,
+        });
+
+        const response = await request(app.getHttpServer())
+          .get(`${validRoute}/invocation6`)
+          .expect(HttpStatus.OK);
+
+        expect(response.body).toEqual(responseExpected);
+      });
+      it('should throw error when try to get one invocation not associated with a team', async () => {
+        const response = await request(app.getHttpServer())
+          .get(`${invalidRoute}/invocation7`)
+          .expect(HttpStatus.BAD_REQUEST);
+
+        expect(response.body.message).toEqual(
+          INVOCATION_RESPONSE.Invocation_NOT_FOUND_BY_TEAM_AND_ID,
+        );
+      });
+    });
+    describe('Update one  - [PUT /invocation]', () => {
+      it('should update one invocation associated with a TEAM', async () => {
+        const responseExpected = expect.objectContaining({
+          id: 'invocation6',
+          name: 'invocation updated',
+        });
+        const response = await request(app.getHttpServer())
+          .patch(`${validRoute}`)
+          .send({
+            name: 'invocation updated',
+            id: 'invocation6',
+          })
+          .expect(HttpStatus.OK);
+
+        expect(response.body).toEqual(responseExpected);
+      });
+      it('should mock generateMethodsFromContractId function', async () => {
+        const spy = jest
+          .spyOn(mockedContractService, 'generateMethodsFromContractId')
+          .mockResolvedValue([]);
+        await request(app.getHttpServer())
+          .patch(`${validRoute}`)
+          .send({
+            name: 'invocation updated',
+            id: 'invocation6',
+            contractId: 'test contract',
+          })
+          .expect(HttpStatus.OK);
+        expect(spy.mock.calls).toHaveLength(1);
+      });
+      it('should remove methods associated with an invocation when update the contract', async () => {
+        jest
+          .spyOn(mockedContractService, 'generateMethodsFromContractId')
+          .mockResolvedValue([
+            {
+              name: 'method5',
+              inputs: [],
+              outputs: [],
+              docs: 'doc0',
+            },
+          ]);
+
+        const expectedResponse = expect.objectContaining({
+          id: 'invocation6',
+          selectedMethod: null,
+          contractId: 'contract test',
+          methods: expect.arrayContaining([
+            expect.objectContaining({
+              name: 'method5',
+            }),
+          ]),
+        });
+        const response = await request(app.getHttpServer())
+          .patch(`${validRoute}`)
+          .send({
+            id: 'invocation6',
+            contractId: 'contract test',
+          })
+          .expect(HttpStatus.OK);
+
+        expect(response.body).toEqual(expectedResponse);
+
+        expect(response.body.methods).toHaveLength(1);
+
+        await request(app.getHttpServer())
+          .get('/method/method5')
+          .expect(HttpStatus.NOT_FOUND);
+
+        await request(app.getHttpServer())
+          .get('/method/method7')
+          .expect(HttpStatus.NOT_FOUND);
+      });
+      it('should throw error when try to update selected method and contract at the same time', async () => {
+        const response = await request(app.getHttpServer())
+          .patch(`${validRoute}`)
+          .send({
+            name: 'invocation updated',
+            id: 'invocation6',
+            contractId: 'test contract',
+            selectedMethodId: 'method7',
+          })
+          .expect(HttpStatus.NOT_FOUND);
+
+        expect(response.body.message).toEqual(
+          INVOCATION_RESPONSE.INVOCATION_FAIL_WITH_NEW_CONTRACT_AND_NEW_METHOD,
+        );
+      });
+      it('should throw error when try to update an invocation not associated with a folder', async () => {
+        const response = await request(app.getHttpServer())
+          .patch(`${validRoute}`)
+          .send({
+            name: 'invocation updated',
+            id: 'invocation',
+          })
+          .expect(HttpStatus.NOT_FOUND);
+
+        expect(response.body.message).toEqual(
+          INVOCATION_RESPONSE.Invocation_NOT_FOUND,
+        );
+      });
+      it('should throw error when try to update and invocation with an invalid contract id', async () => {
+        jest
+          .spyOn(mockedContractService, 'generateMethodsFromContractId')
+          .mockResolvedValue(new Error());
+
+        const response = await request(app.getHttpServer())
+          .patch(`${validRoute}`)
+          .send({
+            name: 'invocation updated',
+            id: 'invocation6',
+            contractId: 'invalid contract id',
+          })
+          .expect(HttpStatus.NOT_FOUND);
+
+        expect(response.body.message).toEqual(
+          INVOCATION_RESPONSE.INVOCATION_FAIL_GENERATE_METHODS_WITH_CONTRACT_ID,
+        );
+      });
+      it('should retry 5 times if generateMethodsFromContractId throws an error', async () => {
+        jest
+          .spyOn(mockedContractService, 'generateMethodsFromContractId')
+          .mockResolvedValue(new Error());
+
+        await request(app.getHttpServer())
+          .patch(`${validRoute}`)
+          .send({
+            name: 'invocation updated',
+            id: 'invocation6',
+            contractId: 'test contract',
+          })
+          .expect(HttpStatus.NOT_FOUND);
+      });
+      it('should update contract id with a selected method', async () => {
+        jest
+          .spyOn(mockedContractService, 'generateMethodsFromContractId')
+          .mockResolvedValue([]);
+        const response = await request(app.getHttpServer())
+          .patch(`${validRoute}`)
+          .send({
+            name: 'invocation updated',
+            id: 'invocation6',
+            contractId: 'new test contract',
+          })
+          .expect(HttpStatus.OK);
+
+        expect(response.body.contractId).toEqual('new test contract');
+      });
+      it('should update contract id with a environment', async () => {
+        jest
+          .spyOn(mockedContractService, 'generateMethodsFromContractId')
+          .mockResolvedValue([]);
+        const contractId = '{{contract_id}}';
+        const response = await request(app.getHttpServer())
+          .patch(`${validRoute}`)
+          .send({
+            id: 'invocation6',
+            contractId,
+          })
+          .expect(HttpStatus.OK);
+
+        expect(response.body.contractId).toEqual(contractId);
+      });
+      it('should update secretKey without removing publicKey', async () => {
+        const response = await request(app.getHttpServer())
+          .patch(`${validRoute}`)
+          .send({
+            name: 'invocation updated',
+            id: 'invocation8',
+            secretKey: 'newSecretKey',
+          })
+          .expect(HttpStatus.OK);
+
+        expect(response.body.publicKey).toEqual('publicKey2');
+        expect(response.body.secretKey).toEqual('newSecretKey');
+      });
+      it('should update pre invocation code', async () => {
+        const preInvocationValue = 'console.log("pre invocation")';
+        const response = await request(app.getHttpServer())
+          .patch(`${validRoute}`)
+          .send({
+            preInvocation: preInvocationValue,
+            id: 'invocation6',
+          })
+          .expect(HttpStatus.OK);
+
+        expect(response.body.preInvocation).toEqual(preInvocationValue);
+      });
+      it('should update post invocation code', async () => {
+        const postInvocationValue = 'console.log("post invocation")';
+        const response = await request(app.getHttpServer())
+          .patch(`${validRoute}`)
+          .send({
+            preInvocation: postInvocationValue,
+            id: 'invocation6',
+          })
+          .expect(HttpStatus.OK);
+
+        expect(response.body.preInvocation).toEqual(postInvocationValue);
+      });
+    });
+    describe('Update Network - [PUT /invocation]', () => {
+      it('should throw error when the invocation id is incorrect', async () => {
+        const response = await request(app.getHttpServer())
+          .patch(`${validRoute}`)
+          .send({ network: 'TESTNET', id: 'invocation' })
+          .expect(HttpStatus.NOT_FOUND);
+
+        expect(response.body.message).toEqual(
+          INVOCATION_RESPONSE.Invocation_NOT_FOUND,
+        );
+      });
+      it('should change to TESTNET network', async () => {
+        const responseExpected = expect.objectContaining({
+          network: 'TESTNET',
+          id: 'invocation6',
+          methods: [],
+        });
+
+        const response = await request(app.getHttpServer())
+          .patch(`${validRoute}`)
+          .send({ network: 'TESTNET', id: 'invocation6' })
+          .expect(HttpStatus.OK);
+
+        expect(response.body).toEqual(responseExpected);
+      });
+      it('should change to FUTURENET network', async () => {
+        const responseExpected = expect.objectContaining({
+          network: 'FUTURENET',
+          id: 'invocation6',
+        });
+
+        const response = await request(app.getHttpServer())
+          .patch(`${validRoute}`)
+          .send({ network: 'FUTURENET', id: 'invocation6' })
+          .expect(HttpStatus.OK);
+
+        expect(response.body).toEqual(responseExpected);
+      });
+    });
+    describe('Run one  - [GET /invocation/:id/run]', () => {
+      it('should run correctly the invocation', async () => {
+        await request(app.getHttpServer())
+          .get(`${validRoute}/invocation11/run`)
+          .expect(HttpStatus.OK);
+      });
+      it('should validate all required fields', async () => {
+        const response = await request(app.getHttpServer())
+          .get(`${validRoute}/invocation10/run`)
+          .expect(HttpStatus.BAD_REQUEST);
+
+        expect(response.body.message).toEqual(
+          INVOCATION_RESPONSE.INVOCATION_FAILED_TO_RUN_WITHOUT_KEYS_OR_SELECTED_METHOD,
+        );
+      });
+    });
+    describe('Delete one  - [DELETE /invocation/:id]', () => {
+      it('should delete one invocation associated with a team', async () => {
+        const response = await request(app.getHttpServer())
+          .delete(`${validRoute}/invocation6`)
+          .expect(HttpStatus.OK);
+
+        expect(response.body).toEqual({});
+      });
+      it('should throw error when try to delete one invocation not associated with a team', async () => {
+        const response = await request(app.getHttpServer())
+          .delete(`${invalidRoute}/invocation7`)
+          .expect(HttpStatus.BAD_REQUEST);
+
+        expect(response.body.message).toEqual(
+          INVOCATION_RESPONSE.Invocation_NOT_FOUND_BY_TEAM_AND_ID,
+        );
+      });
+      it('should throw an unauthorize error when try to delete an invocation with a user without the required role', async () => {
+        const response = await request(app.getHttpServer())
+          .delete(`${unauthorizeRoute}/invocation11`)
+          .expect(HttpStatus.UNAUTHORIZED);
+
+        expect(response.body.message).toEqual(
+          AUTH_RESPONSE.USER_ROLE_NOT_AUTHORIZED,
+        );
+      });
     });
   });
 });

--- a/src/modules/invocation/interface/invocation-team.controller.ts
+++ b/src/modules/invocation/interface/invocation-team.controller.ts
@@ -1,0 +1,66 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
+import { ResilienceInterceptor, RetryStrategy } from 'nestjs-resilience';
+
+import { AdminRoleGuard } from '@/modules/auth/infrastructure/guard/admin-role.guard';
+import { AuthTeamGuard } from '@/modules/auth/infrastructure/guard/auth-team.guard';
+import { JwtAuthGuard } from '@/modules/auth/infrastructure/guard/policy-auth.guard';
+
+import { CreateInvocationDto } from '../application/dto/create-invocation.dto';
+import { UpdateInvocationDto } from '../application/dto/update-invocation.dto';
+import { InvocationService } from '../application/service/invocation.service';
+
+@Controller('/team/:teamId/invocation')
+@UseGuards(JwtAuthGuard, AuthTeamGuard)
+export class InvocationTeamController {
+  constructor(private readonly invocationService: InvocationService) {}
+
+  @UseGuards(AdminRoleGuard)
+  @Post('')
+  async create(
+    @Param('teamId') teamId: string,
+    @Body() createInvocationDto: CreateInvocationDto,
+  ) {
+    return this.invocationService.createByTeam(createInvocationDto, teamId);
+  }
+
+  @Get('/:id')
+  findOne(@Param('teamId') teamId: string, @Param('id') id: string) {
+    return this.invocationService.findOneByInvocationAndTeamIdToDto(id, teamId);
+  }
+
+  @Get('/:id/run')
+  runInvocation(@Param('teamId') teamId: string, @Param('id') id: string) {
+    return this.invocationService.runInvocationByTeam(id, teamId);
+  }
+
+  @Patch('')
+  @UseInterceptors(
+    ResilienceInterceptor(
+      new RetryStrategy({
+        maxRetries: 5,
+      }),
+    ),
+  )
+  update(
+    @Body() updateInvocationDto: UpdateInvocationDto,
+    @Param('teamId') teamId: string,
+  ) {
+    return this.invocationService.updateByTeam(updateInvocationDto, teamId);
+  }
+
+  @UseGuards(AdminRoleGuard)
+  @Delete('/:id')
+  delete(@Param('teamId') teamId: string, @Param('id') id: string) {
+    return this.invocationService.deleteByTeam(id, teamId);
+  }
+}

--- a/src/modules/invocation/interface/invocation.controller.ts
+++ b/src/modules/invocation/interface/invocation.controller.ts
@@ -22,34 +22,31 @@ import { UpdateInvocationDto } from '../application/dto/update-invocation.dto';
 import { InvocationService } from '../application/service/invocation.service';
 
 @Controller('invocation')
-export class InvocationController {
+@UseGuards(JwtAuthGuard)
+export class InvocationUserController {
   constructor(private readonly invocationService: InvocationService) {}
 
-  @UseGuards(JwtAuthGuard)
   @Post('')
-  async create(@Body() createInvocationDto: CreateInvocationDto) {
-    return this.invocationService.create(createInvocationDto);
+  async create(
+    @AuthUser() user: IUserResponse,
+    @Body() createInvocationDto: CreateInvocationDto,
+  ) {
+    return this.invocationService.createByUser(createInvocationDto, user.id);
   }
 
-  @UseGuards(JwtAuthGuard)
-  @Get('')
-  findAll(@AuthUser() user: IUserResponse) {
-    return this.invocationService.findAll(user);
-  }
-
-  @UseGuards(JwtAuthGuard)
   @Get('/:id')
-  findOne(@Param('id') id: string) {
-    return this.invocationService.findOne(id);
+  findOne(@AuthUser() user: IUserResponse, @Param('id') id: string) {
+    return this.invocationService.findOneByInvocationAndUserIdToDto(
+      id,
+      user.id,
+    );
   }
 
-  @UseGuards(JwtAuthGuard)
   @Get('/:id/run')
-  runInvocation(@Param('id') id: string) {
-    return this.invocationService.runInvocation(id);
+  runInvocation(@AuthUser() user: IUserResponse, @Param('id') id: string) {
+    return this.invocationService.runInvocationByUser(id, user.id);
   }
 
-  @UseGuards(JwtAuthGuard)
   @Patch('')
   @UseInterceptors(
     ResilienceInterceptor(
@@ -62,12 +59,11 @@ export class InvocationController {
     @Body() updateInvocationDto: UpdateInvocationDto,
     @AuthUser() user: IUserResponse,
   ) {
-    return this.invocationService.update(updateInvocationDto, user);
+    return this.invocationService.updateByUser(updateInvocationDto, user.id);
   }
 
-  @UseGuards(JwtAuthGuard)
   @Delete('/:id')
-  delete(@Param('id') id: string) {
-    return this.invocationService.delete(id);
+  delete(@AuthUser() user: IUserResponse, @Param('id') id: string) {
+    return this.invocationService.deleteByUser(id, user.id);
   }
 }

--- a/src/modules/invocation/invocation.module.ts
+++ b/src/modules/invocation/invocation.module.ts
@@ -6,13 +6,15 @@ import { CommonModule } from '@/common/common.module';
 import { EnviromentModule } from '../enviroment/enviroment.module';
 import { FolderModule } from '../folder/folder.module';
 import { MethodModule } from '../method/method.module';
+import { TeamModule } from '../team/team.module';
 import { InvocationException } from './application/exceptions/invocation.exceptions';
 import { InvocationMapper } from './application/mapper/invocation.mapper';
 import { INVOCATION_REPOSITORY } from './application/repository/invocation.repository';
 import { InvocationService } from './application/service/invocation.service';
 import { InvocationSchema } from './infrastructure/persistence/invocation.schema';
 import { InvocationRepository } from './infrastructure/persistence/invocation.typeorm.repository';
-import { InvocationController } from './interface/invocation.controller';
+import { InvocationTeamController } from './interface/invocation-team.controller';
+import { InvocationUserController } from './interface/invocation.controller';
 
 @Module({
   imports: [
@@ -21,8 +23,9 @@ import { InvocationController } from './interface/invocation.controller';
     forwardRef(() => MethodModule),
     forwardRef(() => FolderModule),
     forwardRef(() => EnviromentModule),
+    TeamModule,
   ],
-  controllers: [InvocationController],
+  controllers: [InvocationUserController, InvocationTeamController],
   providers: [
     InvocationException,
     InvocationService,

--- a/src/modules/method/application/repository/method.interface.repository.ts
+++ b/src/modules/method/application/repository/method.interface.repository.ts
@@ -7,10 +7,7 @@ import { Method } from '../../domain/method.domain';
 export interface IMethodRepository extends IBaseRepository<Method> {
   saveAll(methods: Method[]): Promise<Method[]>;
   findAll(userId: string): Promise<Method[]>;
-  findAllByInvocationId(
-    invocationId: string,
-    userId: string,
-  ): Promise<Method[]>;
+  findAllByInvocationId(invocationId: string): Promise<Method[]>;
   findOneByIds(id: string, userId: string): Promise<Method>;
   update(param: Method): Promise<Method>;
   delete(id: string): Promise<boolean>;


### PR DESCRIPTION
### Summary

 The invocation module is separated to search by:
- User `[/invocation]`
  - `AuthUser` is added in the controller to validate in the service that the invocations belong to the user,
  - Add in the repository to search using `invocationId` and `userId`
- Team `[/team/:teamId/invocation]`
  - `AuthTeamGuard` is added to verify that the user is a member of the team.
  - `AdminRoleGuard` is added to verify that the user is admin or heigher to create, update and delete invocations.
  - Added in the repository to search using `invocationId` and `teamId`

### Details

- Add invocation controller by team or user
- Add invocation service for team and user
- Add collection relations to find one invocation
- Add find all invocations by folder id
- Add test to find all invocations by folder 
- Add test to new invocation-team.controller
