### PR TITLE
 Feat: Add CRUD method to user and team

### DIFF
--- a/src/modules/invocation/application/service/invocation.service.ts
+++ b/src/modules/invocation/application/service/invocation.service.ts
@@ -210,6 +210,16 @@ export class InvocationService {
     return this.invocationMapper.fromEntityToDto(invocation);
   }
 
+  async findAllMethodsByUser(id: string, userId: string) {
+    const invocation = await this.findOneByInvocationAndUserId(id, userId);
+    return invocation.methods;
+  }
+
+  async findAllMethodsByTeam(id: string, teamId: string) {
+    const invocation = await this.findOneByInvocationAndTeamId(id, teamId);
+    return invocation.methods;
+  }
+
   async findOneByInvocationAndUserId(
     id: string,
     userId: string,

--- a/src/modules/invocation/interface/__test__/invocation.e2e.spec.ts
+++ b/src/modules/invocation/interface/__test__/invocation.e2e.spec.ts
@@ -148,6 +148,37 @@ describe('Invocation - [/invocation]', () => {
       );
     });
   });
+  describe('Get all methods - [GET /invocation/:id/methods]', () => {
+    it('should get all methods associated with a user', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/invocation/invocation0/methods')
+        .expect(HttpStatus.OK);
+
+      expect(response.body).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: 'method0',
+            invocationId: 'invocation0',
+            id: 'method0',
+          }),
+          expect.objectContaining({
+            name: 'method2',
+            invocationId: 'invocation0',
+            id: 'method2',
+          }),
+        ]),
+      );
+    });
+    it('should throw error when try to get all methods not associated with a user', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/invocation/invocation1')
+        .expect(HttpStatus.BAD_REQUEST);
+
+      expect(response.body.message).toEqual(
+        INVOCATION_RESPONSE.Invocation_NOT_FOUND_BY_USER_AND_ID,
+      );
+    });
+  });
 
   describe('Update one  - [PUT /invocation/:id]', () => {
     it('should update one invocation associated with a user', async () => {
@@ -535,6 +566,37 @@ describe('Invocation - [/invocation]', () => {
       it('should throw error when try to get one invocation not associated with a team', async () => {
         const response = await request(app.getHttpServer())
           .get(`${invalidRoute}/invocation7`)
+          .expect(HttpStatus.BAD_REQUEST);
+
+        expect(response.body.message).toEqual(
+          INVOCATION_RESPONSE.Invocation_NOT_FOUND_BY_TEAM_AND_ID,
+        );
+      });
+    });
+    describe('Get all methods - [GET /invocation/:id/methods]', () => {
+      it('should get all methods associated with a team', async () => {
+        const response = await request(app.getHttpServer())
+          .get(`${validRoute}/invocation6/methods`)
+          .expect(HttpStatus.OK);
+
+        expect(response.body).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              name: 'method5',
+              invocationId: 'invocation6',
+              id: 'method5',
+            }),
+            expect.objectContaining({
+              name: 'method7',
+              invocationId: 'invocation6',
+              id: 'method7',
+            }),
+          ]),
+        );
+      });
+      it('should throw error when try to get all methods not associated with a team', async () => {
+        const response = await request(app.getHttpServer())
+          .get(`${invalidRoute}/invocation7/methods`)
           .expect(HttpStatus.BAD_REQUEST);
 
         expect(response.body.message).toEqual(

--- a/src/modules/invocation/interface/invocation-team.controller.ts
+++ b/src/modules/invocation/interface/invocation-team.controller.ts
@@ -43,6 +43,11 @@ export class InvocationTeamController {
     return this.invocationService.runInvocationByTeam(id, teamId);
   }
 
+  @Get('/:id/methods')
+  findAllMethods(@Param('teamId') teamId: string, @Param('id') id: string) {
+    return this.invocationService.findAllMethodsByTeam(id, teamId);
+  }
+
   @Patch('')
   @UseInterceptors(
     ResilienceInterceptor(

--- a/src/modules/invocation/interface/invocation.controller.ts
+++ b/src/modules/invocation/interface/invocation.controller.ts
@@ -47,6 +47,11 @@ export class InvocationUserController {
     return this.invocationService.runInvocationByUser(id, user.id);
   }
 
+  @Get(':id/methods')
+  findAllMethods(@AuthUser() user: IUserResponse, @Param('id') id: string) {
+    return this.invocationService.findAllMethodsByUser(id, user.id);
+  }
+
   @Patch('')
   @UseInterceptors(
     ResilienceInterceptor(

--- a/src/modules/invocation/invocation.module.ts
+++ b/src/modules/invocation/invocation.module.ts
@@ -36,6 +36,7 @@ import { InvocationUserController } from './interface/invocation.controller';
     },
   ],
   exports: [
+    InvocationService,
     InvocationMapper,
     {
       provide: INVOCATION_REPOSITORY,

--- a/src/modules/method/application/exceptions/method-response.enum.ts
+++ b/src/modules/method/application/exceptions/method-response.enum.ts
@@ -3,9 +3,10 @@ export enum METHOD_RESPONSE {
   METHOD_NOT_FOUND_BY_ID = 'Method not found by id',
   METHOD_NOT_FOUND_BY_USER = 'Method not found by user',
   METHOD_NOT_FOUND_BY_USER_AND_ID = 'Method not found by user and id',
+  METHOD_NOT_FOUND_BY_TEAM_AND_ID = 'Method not found by team and id',
   METHOD_NOT_SAVED = 'Method not saved',
   METHOD_NOT_DELETED = 'Method not deleted',
   METHOD_NOT_UPDATED = 'Method not updated',
-  METHOD_INVOCATION_NOT_FOUND = 'Invocation not exists',
+  METHOD_INVOCATION_NOT_FOUND = 'Invocation not found',
   METHODS_NOT_DELETED = 'Error when try to remove methods',
 }

--- a/src/modules/method/application/repository/method.interface.repository.ts
+++ b/src/modules/method/application/repository/method.interface.repository.ts
@@ -6,7 +6,6 @@ import { Method } from '../../domain/method.domain';
 
 export interface IMethodRepository extends IBaseRepository<Method> {
   saveAll(methods: Method[]): Promise<Method[]>;
-  findAll(userId: string): Promise<Method[]>;
   findAllByInvocationId(invocationId: string): Promise<Method[]>;
   findOneByIds(id: string, userId: string): Promise<Method>;
   update(param: Method): Promise<Method>;

--- a/src/modules/method/infrastructure/persistence/method.typeorm.repository.ts
+++ b/src/modules/method/infrastructure/persistence/method.typeorm.repository.ts
@@ -21,7 +21,7 @@ export class MethodRepository implements IMethodRepository {
     return this.repository.save(methods);
   }
 
-  async findAll(invocationId: string): Promise<Method[]> {
+  async findAllByInvocationId(invocationId: string): Promise<Method[]> {
     return await this.repository.find({
       relations: { invocation: true },
       where: {
@@ -30,16 +30,15 @@ export class MethodRepository implements IMethodRepository {
     });
   }
 
-  async findAllByInvocationId(invocationId: string): Promise<Method[]> {
-    return await this.repository.find({
-      where: {
-        invocationId,
-      },
-    });
-  }
-
   async findOne(id: string): Promise<Method> {
     return await this.repository.findOne({
+      relations: {
+        invocation: {
+          folder: {
+            collection: true,
+          },
+        },
+      },
       where: {
         id,
       },

--- a/src/modules/method/interface/__test__/fixture/Collection.yml
+++ b/src/modules/method/interface/__test__/fixture/Collection.yml
@@ -9,3 +9,13 @@ items:
     id: 'collection1'
     name: 'collection1'
     user: '@user1'
+
+  collection2:
+    id: 'collection2'
+    name: 'collection2'
+    teamId: '@team0'
+
+  collection3:
+    id: 'collection3'
+    name: 'collection3'
+    teamId: '@team1'

--- a/src/modules/method/interface/__test__/fixture/Folder.yml
+++ b/src/modules/method/interface/__test__/fixture/Folder.yml
@@ -3,11 +3,19 @@ items:
   folder0:
     id: 'folder0'
     name: 'folder0'
-    user: '@user0'
     collection: '@collection0'
 
   folder1:
     id: 'folder1'
     name: 'folder1'
-    user: '@user1'
     collection: '@collection1'
+
+  folder2:
+    id: 'folder2'
+    name: 'folder2'
+    collection: '@collection2'
+
+  folder3:
+    id: 'folder3'
+    name: 'folder3'
+    collection: '@collection3'

--- a/src/modules/method/interface/__test__/fixture/Invocation.yml
+++ b/src/modules/method/interface/__test__/fixture/Invocation.yml
@@ -4,12 +4,22 @@ items:
     id: 'invocation0'
     name: 'invocation0'
     folder: '@folder0'
-    user: '@user0'
     network: 'FUTURENET'
 
   invocation1:
     id: 'invocation1'
     name: 'invocation1'
     folder: '@folder0'
-    user: '@user1'
+    network: 'FUTURENET'
+
+  invocation2:
+    id: 'invocation2'
+    name: 'invocation2'
+    folder: '@folder2'
+    network: 'FUTURENET'
+
+  invocation3:
+    id: 'invocation3'
+    name: 'invocation3'
+    folder: '@folder3'
     network: 'FUTURENET'

--- a/src/modules/method/interface/__test__/fixture/Method.yml
+++ b/src/modules/method/interface/__test__/fixture/Method.yml
@@ -7,7 +7,6 @@ items:
     outputs: []
     params: []
     docs: 'docs0'
-    user: '@user0'
     invocation: '@invocation0'
 
   method1:
@@ -17,5 +16,22 @@ items:
     outputs: []
     params: []
     docs: 'docs1'
-    user: '@user1'
     invocation: '@invocation1'
+
+  method2:
+    id: 'method2'
+    name: 'method2'
+    inputs: []
+    outputs: []
+    params: []
+    docs: 'docs0'
+    invocation: '@invocation2'
+
+  method3:
+    id: 'method3'
+    name: 'method3'
+    inputs: []
+    outputs: []
+    params: []
+    docs: 'docs1'
+    invocation: '@invocation3'

--- a/src/modules/method/interface/__test__/fixture/Role.yml
+++ b/src/modules/method/interface/__test__/fixture/Role.yml
@@ -1,0 +1,25 @@
+entity: UserRoleToTeam
+items:
+  role0:
+    id: 'role0'
+    teamId: '@team0'
+    userId: '@user0'
+    role: 'OWNER'
+
+  role1:
+    id: 'role1'
+    teamId: '@team1'
+    userId: '@user1'
+    role: 'OWNER'
+
+  role2:
+    id: 'role2'
+    teamId: '@team1'
+    userId: '@user0'
+    role: 'ADMIN'
+
+  role3:
+    id: 'role3'
+    teamId: '@team2'
+    userId: '@user0'
+    role: 'USER'

--- a/src/modules/method/interface/__test__/fixture/Team.yml
+++ b/src/modules/method/interface/__test__/fixture/Team.yml
@@ -1,0 +1,19 @@
+entity: Team
+items:
+  team0:
+    id: 'team0'
+    name: 'team0'
+    adminId: 'user0'
+    users: []
+
+  team1:
+    id: 'team1'
+    name: 'team1'
+    adminId: 'user1'
+    users: ['user0']
+
+  team2:
+    id: 'team2'
+    name: 'team2'
+    adminId: 'user1'
+    users: ['user0']

--- a/src/modules/method/interface/__test__/method.e2e.spec.ts
+++ b/src/modules/method/interface/__test__/method.e2e.spec.ts
@@ -9,6 +9,7 @@ import { AppModule } from '@/app.module';
 import { COGNITO_SERVICE } from '@/modules/auth/application/repository/cognito.interface.service';
 import { JwtAuthGuard } from '@/modules/auth/infrastructure/guard/policy-auth.guard';
 import { JwtStrategy } from '@/modules/auth/infrastructure/jwt/jwt.strategy';
+import { INVOCATION_RESPONSE } from '@/modules/invocation/application/exceptions/invocation-response.enum.dto';
 
 import { METHOD_RESPONSE } from '../../application/exceptions/method-response.enum';
 
@@ -161,6 +162,118 @@ describe('Parameter - [/param]', () => {
         .expect(HttpStatus.NOT_FOUND);
 
       expect(response.body.message).toEqual(METHOD_RESPONSE.METHOD_NOT_FOUND);
+    });
+  });
+  describe('By Team - [/team/:teamId/method]', () => {
+    const validRoute = '/team/team0/method';
+    const invalidRoute = '/team/team1/method';
+    describe('Create one - [POST /method]', () => {
+      it('Should create a new method', async () => {
+        const responseExpected = expect.objectContaining({
+          id: expect.any(String),
+          name: expect.any(String),
+        });
+        const response = await request(app.getHttpServer())
+          .post(`${validRoute}`)
+          .send({
+            name: 'test',
+            inputs: [],
+            outputs: [],
+            params: [],
+            invocationId: 'invocation2',
+          })
+          .expect(HttpStatus.CREATED);
+
+        expect(response.body).toEqual(responseExpected);
+      });
+      it('should throw error when try to create a new method not associated with an invocation ', async () => {
+        const response = await request(app.getHttpServer())
+          .post(`${invalidRoute}`)
+          .send({
+            name: 'test',
+            invocationId: 'invocation2',
+          })
+          .expect(HttpStatus.BAD_REQUEST);
+
+        expect(response.body.message).toEqual(
+          INVOCATION_RESPONSE.Invocation_NOT_FOUND_BY_TEAM_AND_ID,
+        );
+      });
+    });
+
+    describe('Get one - [GET /method/:id]', () => {
+      it('Should get one method associated with a team', async () => {
+        const responseExpected = expect.objectContaining({
+          id: 'method2',
+          name: expect.any(String),
+        });
+
+        const response = await request(app.getHttpServer())
+          .get(`${validRoute}/method2`)
+          .expect(HttpStatus.OK);
+
+        expect(response.body).toEqual(responseExpected);
+      });
+      it('Should throw error when try to get one parameter not associated with a team', async () => {
+        const response = await request(app.getHttpServer())
+          .get(`${invalidRoute}/method2`)
+          .expect(HttpStatus.BAD_REQUEST);
+
+        expect(response.body.message).toEqual(
+          METHOD_RESPONSE.METHOD_NOT_FOUND_BY_TEAM_AND_ID,
+        );
+      });
+    });
+
+    describe('Update one  - [PUT /method/:id]', () => {
+      it('Should update one method associated with a team', async () => {
+        const responseExpected = expect.objectContaining({
+          id: 'method2',
+          name: 'method updated',
+        });
+        const response = await request(app.getHttpServer())
+          .patch(`${validRoute}`)
+          .send({
+            name: 'method updated',
+            id: 'method2',
+            invocationId: 'invocation2',
+          })
+          .expect(HttpStatus.OK);
+
+        expect(response.body).toEqual(responseExpected);
+      });
+      it('should throw error when try to update a method not associated with a team', async () => {
+        const response = await request(app.getHttpServer())
+          .patch(`${invalidRoute}`)
+          .send({
+            name: 'method updated',
+            id: 'method2',
+          })
+          .expect(HttpStatus.BAD_REQUEST);
+
+        expect(response.body.message).toEqual(
+          METHOD_RESPONSE.METHOD_NOT_FOUND_BY_TEAM_AND_ID,
+        );
+      });
+    });
+
+    describe('Delete one  - [DELETE /method/:id]', () => {
+      it('Should delete one method associated with a team', async () => {
+        const response = await request(app.getHttpServer())
+          .delete(`${validRoute}/method2`)
+          .expect(HttpStatus.OK);
+
+        expect(response.body).toEqual({});
+      });
+      it('Should throw error when try to delete one param not associated with a team', async () => {
+        const response = await request(app.getHttpServer())
+          .delete(`${validRoute}/method3`)
+          .expect(HttpStatus.BAD_REQUEST);
+
+        expect(response.body.message).toEqual(
+          METHOD_RESPONSE.METHOD_NOT_FOUND_BY_TEAM_AND_ID,
+        );
+      });
     });
   });
 });

--- a/src/modules/method/interface/method-team.controller.ts
+++ b/src/modules/method/interface/method-team.controller.ts
@@ -1,0 +1,49 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+
+import { AuthTeamGuard } from '@/modules/auth/infrastructure/guard/auth-team.guard';
+import { JwtAuthGuard } from '@/modules/auth/infrastructure/guard/policy-auth.guard';
+
+import { CreateMethodDto } from '../application/dto/create-method.dto';
+import { UpdateMethodDto } from '../application/dto/update-method.dto';
+import { MethodService } from '../application/service/method.service';
+
+@Controller('/team/:teamId/method')
+@UseGuards(JwtAuthGuard, AuthTeamGuard)
+export class MethodTeamController {
+  constructor(private readonly methodService: MethodService) {}
+
+  @Post('')
+  async create(
+    @Param('teamId') teamId: string,
+    @Body() createMethodDto: CreateMethodDto,
+  ) {
+    return this.methodService.createByTeam(createMethodDto, teamId);
+  }
+
+  @Get('/:id')
+  findOne(@Param('teamId') teamId: string, @Param('id') id: string) {
+    return this.methodService.findOneByMethodAndTeamId(id, teamId);
+  }
+
+  @Patch('')
+  update(
+    @Param('teamId') teamId: string,
+    @Body() updateMethodDto: UpdateMethodDto,
+  ) {
+    return this.methodService.updateByTeam(updateMethodDto, teamId);
+  }
+
+  @Delete('/:id')
+  delete(@Param('teamId') teamId: string, @Param('id') id: string) {
+    return this.methodService.deleteByTeam(id, teamId);
+  }
+}

--- a/src/modules/method/interface/method.controller.ts
+++ b/src/modules/method/interface/method.controller.ts
@@ -20,36 +20,33 @@ import { UpdateMethodDto } from '../application/dto/update-method.dto';
 import { MethodService } from '../application/service/method.service';
 
 @Controller('method')
-export class MethodController {
+@UseGuards(JwtAuthGuard)
+export class MethodUserController {
   constructor(private readonly methodService: MethodService) {}
 
-  @UseGuards(JwtAuthGuard)
   @Post('')
-  async create(@Body() createMethodDto: CreateMethodDto) {
-    return this.methodService.create(createMethodDto);
+  async create(
+    @AuthUser() user: IUserResponse,
+    @Body() createMethodDto: CreateMethodDto,
+  ) {
+    return this.methodService.createByUser(createMethodDto, user.id);
   }
 
-  @UseGuards(JwtAuthGuard)
-  @Get('')
-  findAll(@AuthUser() user: IUserResponse) {
-    return this.methodService.findAll(user);
-  }
-
-  @UseGuards(JwtAuthGuard)
   @Get('/:id')
-  findOne(@Param('id') id: string) {
-    return this.methodService.findOne(id);
+  findOne(@AuthUser() user: IUserResponse, @Param('id') id: string) {
+    return this.methodService.findOneByMethodAndUserId(id, user.id);
   }
 
-  @UseGuards(JwtAuthGuard)
   @Patch()
-  update(@Body() updateMethodDto: UpdateMethodDto) {
-    return this.methodService.update(updateMethodDto);
+  update(
+    @AuthUser() user: IUserResponse,
+    @Body() updateMethodDto: UpdateMethodDto,
+  ) {
+    return this.methodService.updateByUser(updateMethodDto, user.id);
   }
 
-  @UseGuards(JwtAuthGuard)
   @Delete('/:id')
-  delete(@Param('id') id: string) {
-    return this.methodService.delete(id);
+  delete(@AuthUser() user: IUserResponse, @Param('id') id: string) {
+    return this.methodService.deleteByUser(id, user.id);
   }
 }

--- a/src/modules/method/method.module.ts
+++ b/src/modules/method/method.module.ts
@@ -2,19 +2,22 @@ import { Module, forwardRef } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { InvocationModule } from '../invocation/invocation.module';
+import { TeamModule } from '../team/team.module';
 import { MethodMapper } from './application/mapper/method.mapper';
 import { METHOD_REPOSITORY } from './application/repository/method.interface.repository';
 import { MethodService } from './application/service/method.service';
 import { MethodSchema } from './infrastructure/persistence/method.schema';
 import { MethodRepository } from './infrastructure/persistence/method.typeorm.repository';
-import { MethodController } from './interface/method.controller';
+import { MethodTeamController } from './interface/method-team.controller';
+import { MethodUserController } from './interface/method.controller';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([MethodSchema]),
     forwardRef(() => InvocationModule),
+    TeamModule,
   ],
-  controllers: [MethodController],
+  controllers: [MethodUserController, MethodTeamController],
   providers: [
     MethodService,
     MethodMapper,


### PR DESCRIPTION
Feat: Add CRUD method to user and team

### Summary
 The method module is separated to search by:
- User `[/method]`
 - `AuthUser` is added in the controller to validate in the service that the methods belong to the user,
 - Add in the repository to search using `methodId` and `userId`
- Team `[/team/:teamId/method]`
 - `AuthTeamGuard` is added to verify that the user is a member of the team.
 - Added in the repository to search using `methodId` and `teamId`

### Details

- Add method controller by team or user
- Add method service for team and user
- Add find all methods by invocation id
- Add test to find all methods by invocation 
- Add test to new method-team.controller