### PR TITLE
feat: Add Stellar Asset Contract

### DIFF
--- a/src/common/application/mapper/contract.mapper.ts
+++ b/src/common/application/mapper/contract.mapper.ts
@@ -2,7 +2,7 @@ import { nativeToScVal, scValToNative, xdr } from 'stellar-sdk';
 
 import { Method } from '@/modules/method/domain/method.domain';
 
-import { EventResponse } from '../types/contract-events';
+import { EncodeEvent, EventResponse } from '../types/contract-events';
 import { SC_VAL_TYPE } from '../types/soroban.enum';
 
 type Param = {
@@ -31,7 +31,7 @@ export class StellarMapper {
     SC_SPEC_TYPE_MAP: 'map',
   };
 
-  encodeEventToDisplayEvent(events: EventResponse[]) {
+  encodeEventToDisplayEvent(events: EncodeEvent[]): EventResponse[] {
     return events.map((event) => {
       return {
         type: event.type,

--- a/src/common/application/mapper/contract.mapper.ts
+++ b/src/common/application/mapper/contract.mapper.ts
@@ -1,21 +1,84 @@
-import { scValToNative } from 'stellar-sdk';
+import { nativeToScVal, scValToNative, xdr } from 'stellar-sdk';
+
+import { Method } from '@/modules/method/domain/method.domain';
 
 import { EventResponse } from '../types/contract-events';
+import { SC_VAL_TYPE } from '../types/soroban.enum';
 
-export function encodeEventToDisplayEvent(events: EventResponse[]) {
-  return events.map((event) => {
-    return {
-      type: event.type,
-      ledger: event.ledger,
-      ledgerClosedAt: event.ledgerClosedAt,
-      id: event.id,
-      pagingToken: event.pagingToken,
-      topic: event.topic.map((topic) => {
-        return scValToNative(topic);
-      }),
-      value: scValToNative(event.value),
-      inSuccessfulContractCall: event.inSuccessfulContractCall,
-      contractId: event.contractId?.contractId(),
-    };
-  });
+type Param = {
+  value: string;
+  type: any;
+};
+export class StellarMapper {
+  SCSpecTypeMap = {
+    SC_SPEC_TYPE_BOOL: 'b',
+    SC_SPEC_TYPE_ERROR: 'error',
+    SC_SPEC_TYPE_U32: 'u32',
+    SC_SPEC_TYPE_I32: 'i32',
+    SC_SPEC_TYPE_U64: 'u64',
+    SC_SPEC_TYPE_I64: 'i64',
+    SC_SPEC_TYPE_TIMEPOINT: 'timepoint',
+    SC_SPEC_TYPE_DURATION: 'duration',
+    SC_SPEC_TYPE_U128: 'u128',
+    SC_SPEC_TYPE_I128: 'i128',
+    SC_SPEC_TYPE_U256: 'u256',
+    SC_SPEC_TYPE_I256: 'i256',
+    SC_SPEC_TYPE_BYTES: 'bytes',
+    SC_SPEC_TYPE_STRING: 'str',
+    SC_SPEC_TYPE_SYMBOL: 'sym',
+    SC_SPEC_TYPE_ADDRESS: 'address',
+    SC_SPEC_TYPE_VEC: 'vec',
+    SC_SPEC_TYPE_MAP: 'map',
+  };
+
+  encodeEventToDisplayEvent(events: EventResponse[]) {
+    return events.map((event) => {
+      return {
+        type: event.type,
+        ledger: event.ledger,
+        ledgerClosedAt: event.ledgerClosedAt,
+        id: event.id,
+        pagingToken: event.pagingToken,
+        topic: event.topic.map((topic) => {
+          return scValToNative(topic);
+        }),
+        value: this.fromScValToDisplayValue(event.value),
+        inSuccessfulContractCall: event.inSuccessfulContractCall,
+        contractId: event.contractId?.contractId(),
+      };
+    });
+  }
+
+  getScValFromStellarAssetContract(selectedMethod: Method): xdr.ScVal[] {
+    const params = this.getParamsFromStellarAssetContract(selectedMethod);
+    return params.map((param) =>
+      nativeToScVal(param.value, { type: param.type }),
+    );
+  }
+
+  getParamsFromStellarAssetContract(selectedMethod: Method): Param[] {
+    return selectedMethod.params.map((param) => {
+      return {
+        value: param.value,
+        type: this.SCSpecTypeMap[
+          selectedMethod.inputs.find((input) => input.name === param.name).type
+        ],
+      };
+    });
+  }
+
+  fromScValToDisplayValue(value: xdr.ScVal) {
+    switch (value.switch().name) {
+      case SC_VAL_TYPE.STRING:
+        return scValToNative(value);
+      case SC_VAL_TYPE.ADDRESS:
+        return scValToNative(value);
+      case SC_VAL_TYPE.I128:
+        return Number(scValToNative(value));
+      case SC_VAL_TYPE.BOOL:
+        return scValToNative(value);
+      default:
+        return value.value();
+    }
+  }
 }

--- a/src/common/application/repository/contract.interface.service.ts
+++ b/src/common/application/repository/contract.interface.service.ts
@@ -8,8 +8,9 @@ import { EventResponse } from '../types/contract-events';
 export interface IContractService {
   verifyNetwork(selectedNetwork: string): void;
   changeNetwork(selectedNetwork: string): void;
-  getInstanceValue(contractId: string): Promise<xdr.ContractDataEntry>;
-  getWasmCode(instance: xdr.ScContractInstance): Promise<Buffer>;
+  getStellarAssetContractFunctions(): IGeneratedMethod[];
+  getInstanceValue(contractId: string): Promise<xdr.ContractExecutable>;
+  getWasmCode(instance: xdr.ContractExecutable): Promise<Buffer>;
   decodeContractSpecBuffer(buffer);
   extractFunctionInfo(decodedSection, SCSpecTypeMap);
   getContractEvents(contractId: string): Promise<EventResponse[]>;

--- a/src/common/application/repository/contract.interface.service.ts
+++ b/src/common/application/repository/contract.interface.service.ts
@@ -17,6 +17,10 @@ export interface IContractService {
   generateMethodsFromContractId(
     contractId: string,
   ): Promise<IGeneratedMethod[]>;
+  generateScArgsToFromContractId(
+    contractId: string,
+    selectedMethod: Method,
+  ): Promise<xdr.ScVal[]>;
   runInvocation(
     publicKey: string,
     secretKey: string,

--- a/src/common/application/repository/contract.interface.service.ts
+++ b/src/common/application/repository/contract.interface.service.ts
@@ -3,7 +3,7 @@ import { xdr } from 'stellar-sdk';
 import { Method } from '@/modules/method/domain/method.domain';
 
 import { IGeneratedMethod } from '../service/stellar.service';
-import { EventResponse } from '../types/contract-events';
+import { EncodeEvent } from '../types/contract-events';
 
 export interface IContractService {
   verifyNetwork(selectedNetwork: string): void;
@@ -13,7 +13,7 @@ export interface IContractService {
   getWasmCode(instance: xdr.ContractExecutable): Promise<Buffer>;
   decodeContractSpecBuffer(buffer);
   extractFunctionInfo(decodedSection, SCSpecTypeMap);
-  getContractEvents(contractId: string): Promise<EventResponse[]>;
+  getContractEvents(contractId: string): Promise<EncodeEvent[]>;
   generateMethodsFromContractId(
     contractId: string,
   ): Promise<IGeneratedMethod[]>;

--- a/src/common/application/service/__test__/stellar.service.spec.ts
+++ b/src/common/application/service/__test__/stellar.service.spec.ts
@@ -3,6 +3,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { xdr } from 'stellar-sdk';
 
 import { MethodMapper } from '@/modules/method/application/mapper/method.mapper';
+import { Method } from '@/modules/method/domain/method.domain';
 
 import { StellarMapper } from '../../mapper/contract.mapper';
 import { CONTRACT_EXECUTABLE_TYPE, NETWORK } from '../../types/soroban.enum';
@@ -93,6 +94,57 @@ describe('StellarService', () => {
       expect(service.getInstanceValue).toHaveBeenCalled();
       expect(service.getStellarAssetContractFunctions).not.toHaveBeenCalled();
       expect(service.getContractSpecEntries).toHaveBeenCalled();
+      expect(result).toEqual([]);
+    });
+  });
+  describe('generateScArgsToFromContractId', () => {
+    const mockedMethod = new Method('mock', [], [], [], 'mock');
+
+    it('Should return the stellar asset contract arguments', async () => {
+      jest
+        .spyOn(service, 'getInstanceValue')
+        .mockResolvedValue(contractExecutable);
+      jest.spyOn(contractExecutable, 'switch').mockReturnValue({
+        name: CONTRACT_EXECUTABLE_TYPE.STELLAR_ASSET,
+        value: 1,
+      });
+      jest
+        .spyOn(stellarMapper, 'getScValFromStellarAssetContract')
+        .mockReturnValue([]);
+      jest.spyOn(service, 'getScValFromSmartContract');
+
+      const result = await service.generateScArgsToFromContractId(
+        'contractId',
+        mockedMethod,
+      );
+
+      expect(service.getInstanceValue).toHaveBeenCalled();
+      expect(stellarMapper.getScValFromStellarAssetContract).toHaveBeenCalled();
+      expect(service.getScValFromSmartContract).not.toHaveBeenCalled();
+      expect(result).toEqual([]);
+    });
+    it('Should return the smart contract arguments', async () => {
+      jest
+        .spyOn(service, 'getInstanceValue')
+        .mockResolvedValue(contractExecutable);
+      jest.spyOn(contractExecutable, 'switch').mockReturnValue({
+        name: CONTRACT_EXECUTABLE_TYPE.WASM,
+        value: 0,
+      });
+      jest.spyOn(stellarMapper, 'getScValFromStellarAssetContract');
+      jest.spyOn(service, 'getContractSpecEntries').mockResolvedValue([]);
+      jest.spyOn(service, 'getScValFromSmartContract').mockResolvedValue([]);
+
+      const result = await service.generateScArgsToFromContractId(
+        'contractId',
+        mockedMethod,
+      );
+
+      expect(service.getInstanceValue).toHaveBeenCalled();
+      expect(
+        stellarMapper.getScValFromStellarAssetContract,
+      ).not.toHaveBeenCalled();
+      expect(service.getScValFromSmartContract).toHaveBeenCalled();
       expect(result).toEqual([]);
     });
   });

--- a/src/common/application/service/__test__/stellar.service.spec.ts
+++ b/src/common/application/service/__test__/stellar.service.spec.ts
@@ -1,10 +1,19 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { Test, TestingModule } from '@nestjs/testing';
+import { xdr } from 'stellar-sdk';
 
 import { MethodMapper } from '@/modules/method/application/mapper/method.mapper';
 
 import { StellarMapper } from '../../mapper/contract.mapper';
-import { NETWORK } from '../../types/soroban.enum';
+import { CONTRACT_EXECUTABLE_TYPE, NETWORK } from '../../types/soroban.enum';
 import { StellarService } from '../stellar.service';
+
+const contractExecutable: xdr.ContractExecutable = {
+  switch: jest.fn(),
+  wasmHash: jest.fn(),
+  value: jest.fn(),
+  toXDR: jest.fn(),
+};
 
 describe('StellarService', () => {
   let service: StellarService;
@@ -39,6 +48,52 @@ describe('StellarService', () => {
 
       expect(changeNetworkSpy).toHaveBeenCalledWith(selectedNetwork);
       expect(changeNetworkSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+  describe('generateMethodsFromContractId', () => {
+    it('Should return the stellar asset contract functions', async () => {
+      jest
+        .spyOn(service, 'getInstanceValue')
+        .mockResolvedValue(contractExecutable);
+      jest.spyOn(contractExecutable, 'switch').mockReturnValue({
+        name: CONTRACT_EXECUTABLE_TYPE.STELLAR_ASSET,
+        value: 1,
+      });
+      jest
+        .spyOn(service, 'getStellarAssetContractFunctions')
+        .mockReturnValue([]);
+      jest.spyOn(service, 'getContractSpecEntries');
+
+      const result = await service.generateMethodsFromContractId('contractId');
+
+      expect(service.getInstanceValue).toHaveBeenCalled();
+      expect(service.getStellarAssetContractFunctions).toHaveBeenCalled();
+      expect(service.getContractSpecEntries).not.toHaveBeenCalled();
+      expect(result).toEqual([]);
+    });
+    it('Should return the smart contract functions', async () => {
+      jest
+        .spyOn(service, 'getInstanceValue')
+        .mockResolvedValue(contractExecutable);
+      jest.spyOn(contractExecutable, 'switch').mockReturnValue({
+        name: CONTRACT_EXECUTABLE_TYPE.WASM,
+        value: 0,
+      });
+      jest.spyOn(service, 'getStellarAssetContractFunctions');
+      jest.spyOn(service, 'getContractSpecEntries').mockResolvedValue([]);
+      jest.spyOn(service, 'extractFunctionInfo').mockReturnValue({
+        name: '',
+        docs: '',
+        inputs: [],
+        outputs: [],
+      });
+
+      const result = await service.generateMethodsFromContractId('contractId');
+
+      expect(service.getInstanceValue).toHaveBeenCalled();
+      expect(service.getStellarAssetContractFunctions).not.toHaveBeenCalled();
+      expect(service.getContractSpecEntries).toHaveBeenCalled();
+      expect(result).toEqual([]);
     });
   });
 });

--- a/src/common/application/service/__test__/stellar.service.spec.ts
+++ b/src/common/application/service/__test__/stellar.service.spec.ts
@@ -2,20 +2,23 @@ import { Test, TestingModule } from '@nestjs/testing';
 
 import { MethodMapper } from '@/modules/method/application/mapper/method.mapper';
 
+import { StellarMapper } from '../../mapper/contract.mapper';
 import { NETWORK } from '../../types/soroban.enum';
 import { StellarService } from '../stellar.service';
 
 describe('StellarService', () => {
   let service: StellarService;
   let methodMapper: MethodMapper;
+  let stellarMapper: StellarMapper;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [StellarService, MethodMapper],
+      providers: [StellarService, MethodMapper, StellarMapper],
     }).compile();
 
     service = module.get<StellarService>(StellarService);
     methodMapper = module.get<MethodMapper>(MethodMapper);
+    stellarMapper = module.get<StellarMapper>(StellarMapper);
   });
 
   describe('verifyNetwork', () => {

--- a/src/common/application/service/stellar.service.ts
+++ b/src/common/application/service/stellar.service.ts
@@ -18,11 +18,16 @@ import {
 } from 'stellar-sdk';
 
 import { MethodMapper } from '@/modules/method/application/mapper/method.mapper';
+import { Method } from '@/modules/method/domain/method.domain';
 
-import { encodeEventToDisplayEvent } from '../mapper/contract.mapper';
+import { StellarMapper } from '../mapper/contract.mapper';
 import { IContractService } from '../repository/contract.interface.service';
 import { EventResponse } from '../types/contract-events';
-import { NETWORK, SOROBAN_SERVER } from '../types/soroban.enum';
+import {
+  CONTRACT_EXECUTABLE_TYPE,
+  NETWORK,
+  SOROBAN_SERVER,
+} from '../types/soroban.enum';
 
 export interface IGeneratedMethod {
   name: string;
@@ -39,6 +44,7 @@ export class StellarService implements IContractService {
   private currentNetwork: string;
   constructor(
     @Inject(MethodMapper) private readonly methodMapper: MethodMapper,
+    @Inject(StellarMapper) private readonly stellarMapper: StellarMapper,
   ) {
     this.server = new SorobanRpc.Server(SOROBAN_SERVER.FUTURENET);
     this.networkPassphrase = Networks.FUTURENET;
@@ -100,6 +106,291 @@ export class StellarService implements IContractService {
         this.currentNetwork = NETWORK.SOROBAN_MAINNET;
         break;
     }
+  }
+
+  getStellarAssetContractFunctions(): IGeneratedMethod[] {
+    return [
+      {
+        name: 'allowance',
+        docs: null,
+        inputs: [
+          {
+            name: 'from',
+            type: 'SC_SPEC_TYPE_ADDRESS',
+          },
+          {
+            name: 'spender',
+            type: 'SC_SPEC_TYPE_ADDRESS',
+          },
+        ],
+        outputs: [
+          {
+            type: 'SC_SPEC_TYPE_I128',
+          },
+        ],
+      },
+      {
+        name: 'authorized',
+        docs: null,
+        inputs: [
+          {
+            name: 'id',
+            type: 'SC_SPEC_TYPE_ADDRESS',
+          },
+        ],
+        outputs: [
+          {
+            type: 'SC_SPEC_TYPE_BOOL',
+          },
+        ],
+      },
+      {
+        name: 'approve',
+        docs: null,
+        inputs: [
+          {
+            name: 'from',
+            type: 'SC_SPEC_TYPE_ADDRESS',
+          },
+          {
+            name: 'spender',
+            type: 'SC_SPEC_TYPE_ADDRESS',
+          },
+          {
+            name: 'amount',
+            type: 'SC_SPEC_TYPE_I128',
+          },
+          {
+            name: 'expiration_ledger',
+            type: 'SC_SPEC_TYPE_I32',
+          },
+        ],
+        outputs: [
+          {
+            type: 'SC_SPEC_TYPE_RESULT',
+          },
+        ],
+      },
+      {
+        name: 'balance',
+        docs: null,
+        inputs: [
+          {
+            name: 'id',
+            type: 'SC_SPEC_TYPE_ADDRESS',
+          },
+        ],
+        outputs: [
+          {
+            type: 'SC_SPEC_TYPE_I128',
+          },
+        ],
+      },
+      {
+        name: 'burn',
+        docs: null,
+        inputs: [
+          {
+            name: 'from',
+            type: 'SC_SPEC_TYPE_ADDRESS',
+          },
+          {
+            name: 'amount',
+            type: 'SC_SPEC_TYPE_I128',
+          },
+        ],
+        outputs: [
+          {
+            type: 'SC_SPEC_TYPE_RESULT',
+          },
+        ],
+      },
+      {
+        name: 'burn_from',
+        docs: null,
+        inputs: [
+          {
+            name: 'spender',
+            type: 'SC_SPEC_TYPE_ADDRESS',
+          },
+          {
+            name: 'from',
+            type: 'SC_SPEC_TYPE_ADDRESS',
+          },
+          {
+            name: 'amount',
+            type: 'SC_SPEC_TYPE_I128',
+          },
+        ],
+        outputs: [
+          {
+            type: 'SC_SPEC_TYPE_I128',
+          },
+        ],
+      },
+      {
+        name: 'clawback',
+        docs: null,
+        inputs: [
+          {
+            name: 'from',
+            type: 'SC_SPEC_TYPE_ADDRESS',
+          },
+          {
+            name: 'amount',
+            type: 'SC_SPEC_TYPE_I128',
+          },
+        ],
+        outputs: [
+          {
+            type: 'SC_SPEC_TYPE_I128',
+          },
+        ],
+      },
+      {
+        name: 'decimals',
+        docs: null,
+        inputs: [],
+        outputs: [
+          {
+            type: 'SC_SPEC_TYPE_RESULT',
+          },
+        ],
+      },
+      {
+        name: 'mint',
+        docs: null,
+        inputs: [
+          {
+            name: 'to',
+            type: 'SC_SPEC_TYPE_ADDRESS',
+          },
+          {
+            name: 'amount',
+            type: 'SC_SPEC_TYPE_I128',
+          },
+        ],
+        outputs: [
+          {
+            type: 'SC_SPEC_TYPE_RESULT',
+          },
+        ],
+      },
+      {
+        name: 'name',
+        docs: null,
+        inputs: [],
+        outputs: [
+          {
+            type: 'SC_SPEC_TYPE_STRING',
+          },
+        ],
+      },
+      {
+        name: 'set_admin',
+        docs: null,
+        inputs: [
+          {
+            name: 'new_admin',
+            type: 'SC_SPEC_TYPE_ADDRESS',
+          },
+        ],
+        outputs: [
+          {
+            type: 'SC_SPEC_TYPE_RESULT',
+          },
+        ],
+      },
+      {
+        name: 'admin',
+        docs: null,
+        inputs: [],
+        outputs: [
+          {
+            type: 'SC_SPEC_TYPE_RESULT',
+          },
+        ],
+      },
+      {
+        name: 'set_authorized',
+        docs: null,
+        inputs: [
+          {
+            name: 'id',
+            type: 'SC_SPEC_TYPE_ADDRESS',
+          },
+          {
+            name: 'authorize',
+            type: 'SC_SPEC_TYPE_BOOL',
+          },
+        ],
+        outputs: [
+          {
+            type: 'SC_SPEC_TYPE_RESULT',
+          },
+        ],
+      },
+      {
+        name: 'symbol',
+        docs: null,
+        inputs: [],
+        outputs: [
+          {
+            type: 'SC_SPEC_TYPE_STRING',
+          },
+        ],
+      },
+      {
+        name: 'transfer',
+        docs: null,
+        inputs: [
+          {
+            name: 'from',
+            type: 'SC_SPEC_TYPE_ADDRESS',
+          },
+          {
+            name: 'to',
+            type: 'SC_SPEC_TYPE_ADDRESS',
+          },
+          {
+            name: 'amount',
+            type: 'SC_SPEC_TYPE_I128',
+          },
+        ],
+        outputs: [
+          {
+            type: 'SC_SPEC_TYPE_RESULT',
+          },
+        ],
+      },
+      {
+        name: 'transfer_from',
+        docs: null,
+        inputs: [
+          {
+            name: 'spender',
+            type: 'SC_SPEC_TYPE_ADDRESS',
+          },
+          {
+            name: 'from',
+            type: 'SC_SPEC_TYPE_ADDRESS',
+          },
+          {
+            name: 'to',
+            type: 'SC_SPEC_TYPE_ADDRESS',
+          },
+          {
+            name: 'amount',
+            type: 'SC_SPEC_TYPE_I128',
+          },
+        ],
+        outputs: [
+          {
+            type: 'SC_SPEC_TYPE_RESULT',
+          },
+        ],
+      },
+    ];
   }
 
   async decodeContractSpecBuffer(buffer) {
@@ -183,7 +474,7 @@ export class StellarService implements IContractService {
     return functionObj;
   }
 
-  async getInstanceValue(contractId: string): Promise<xdr.ContractDataEntry> {
+  async getInstanceValue(contractId: string): Promise<xdr.ContractExecutable> {
     try {
       const instanceKey = xdr.LedgerKey.contractData(
         new xdr.LedgerKeyContractData({
@@ -193,18 +484,22 @@ export class StellarService implements IContractService {
         }),
       );
       const response = await this.server.getLedgerEntries(instanceKey);
-      const dataEntry = response.entries[0].val.contractData();
+      const dataEntry = response.entries[0].val
+        .contractData()
+        .val()
+        .instance()
+        .executable();
       return dataEntry;
     } catch (error) {
       console.log('Error while getting instance value: ', error);
     }
   }
 
-  async getWasmCode(instance: xdr.ScContractInstance): Promise<Buffer> {
+  async getWasmCode(instance: xdr.ContractExecutable): Promise<Buffer> {
     try {
       const codeKey = xdr.LedgerKey.contractCode(
         new xdr.LedgerKeyContractCode({
-          hash: instance.executable().wasmHash(),
+          hash: instance.wasmHash(),
         }),
       );
       const response = await this.server.getLedgerEntries(codeKey);
@@ -215,12 +510,9 @@ export class StellarService implements IContractService {
     }
   }
 
-  async getContractSpecEntries(contractId) {
+  async getContractSpecEntries(instanceValue: xdr.ContractExecutable) {
     try {
-      const instanceValue = await this.getInstanceValue(contractId);
-      const contractCode = await this.getWasmCode(
-        instanceValue.val().instance(),
-      );
+      const contractCode = await this.getWasmCode(instanceValue);
       const wasmModule = new WebAssembly.Module(contractCode);
       const buffer = WebAssembly.Module.customSections(
         wasmModule,
@@ -245,47 +537,22 @@ export class StellarService implements IContractService {
           contractIds: [contractId],
         },
       ],
-      limit: 100,
+      limit: 20,
     });
     return events.reverse();
   }
 
-  async generateMethodsFromContractId(contractId: string) {
-    try {
-      const decodedSections = await this.getContractSpecEntries(contractId);
-
-      const functions = decodedSections
-        .map((decodedSection) =>
-          this.extractFunctionInfo(decodedSection, this.SCSpecTypeMap),
-        )
-        .filter((f) => {
-          return Object.keys(f).length > 0 && f.name.length > 0;
-        });
-
-      return functions;
-    } catch (error) {
-      throw new Error(error);
-    }
-  }
-
-  @UseInterceptors(
-    ResilienceInterceptor(
-      new RetryStrategy({
-        maxRetries: 5,
-      }),
-    ),
-  )
-  async runInvocation(publicKey, secretKey, contractId, selectedMethod) {
-    const account = await this.server.getAccount(publicKey);
-    const contract = new Contract(contractId);
-
+  async getScValFromSmartContract(
+    instanceValue: xdr.ContractExecutable,
+    selectedMethod: Method,
+  ): Promise<xdr.ScVal[]> {
     const maxRetries = 7;
     let retries = 0;
     let specEntries;
 
     while (retries < maxRetries) {
       try {
-        specEntries = await this.getContractSpecEntries(contractId);
+        specEntries = await this.getContractSpecEntries(instanceValue);
         break;
       } catch (error) {
         console.log(
@@ -313,21 +580,76 @@ export class StellarService implements IContractService {
         [param.name]: isU32 ? parseInt(param.value) : param.value,
       };
     }, {});
-    const scArgs = contractSpec.funcArgsToScVals(selectedMethod.name, params);
 
-    let transaction: any = new TransactionBuilder(account, {
+    return contractSpec.funcArgsToScVals(selectedMethod.name, params);
+  }
+
+  async generateMethodsFromContractId(contractId: string) {
+    try {
+      const instanceValue = await this.getInstanceValue(contractId);
+      if (
+        instanceValue.switch().name === CONTRACT_EXECUTABLE_TYPE.STELLAR_ASSET
+      ) {
+        return this.getStellarAssetContractFunctions();
+      } else {
+        const decodedSections = await this.getContractSpecEntries(
+          instanceValue,
+        );
+
+        const functions = decodedSections
+          .map((decodedSection) =>
+            this.extractFunctionInfo(decodedSection, this.SCSpecTypeMap),
+          )
+          .filter((f) => {
+            return Object.keys(f).length > 0 && f.name.length > 0;
+          });
+
+        return functions;
+      }
+    } catch (error) {
+      throw new Error(error);
+    }
+  }
+
+  @UseInterceptors(
+    ResilienceInterceptor(
+      new RetryStrategy({
+        maxRetries: 5,
+      }),
+    ),
+  )
+  async runInvocation(publicKey, secretKey, contractId, selectedMethod) {
+    const account = await this.server.getAccount(publicKey);
+    const contract = new Contract(contractId);
+    let scArgs: xdr.ScVal[];
+
+    const instanceValue = await this.getInstanceValue(contractId);
+
+    if (
+      instanceValue.switch().name === CONTRACT_EXECUTABLE_TYPE.STELLAR_ASSET
+    ) {
+      scArgs =
+        this.stellarMapper.getScValFromStellarAssetContract(selectedMethod);
+    } else {
+      scArgs = await this.getScValFromSmartContract(
+        instanceValue,
+        selectedMethod,
+      );
+    }
+
+    let transaction = new TransactionBuilder(account, {
       fee: BASE_FEE,
       networkPassphrase: this.networkPassphrase,
     })
       .addOperation(contract.call(selectedMethod.name, ...scArgs))
       .setTimeout(60)
       .build();
+
     transaction = await this.server.prepareTransaction(transaction);
     transaction.sign(Keypair.fromSecret(secretKey));
 
     try {
       const response = await this.server._sendTransaction(transaction);
-
       if (response.status === 'ERROR') {
         return response;
       }
@@ -339,16 +661,21 @@ export class StellarService implements IContractService {
 
         await new Promise((resolve) => setTimeout(resolve, 1000));
       }
+
       const methodMapped = this.methodMapper.fromDtoToEntity(selectedMethod);
+
       if (newresponse.status === 'SUCCESS') {
         const events = await this.getContractEvents(contractId);
         return {
           method: methodMapped,
-          response: newresponse.returnValue.value(),
+          response: this.stellarMapper.fromScValToDisplayValue(
+            newresponse.returnValue,
+          ),
           status: newresponse.status,
-          events: encodeEventToDisplayEvent(events),
+          events: this.stellarMapper.encodeEventToDisplayEvent(events),
         };
       }
+
       const rawResponse = await this.server._getTransaction(response.hash);
       return {
         STATUS: rawResponse.status,

--- a/src/common/application/service/stellar.service.ts
+++ b/src/common/application/service/stellar.service.ts
@@ -22,7 +22,7 @@ import { Method } from '@/modules/method/domain/method.domain';
 
 import { StellarMapper } from '../mapper/contract.mapper';
 import { IContractService } from '../repository/contract.interface.service';
-import { EventResponse } from '../types/contract-events';
+import { EncodeEvent } from '../types/contract-events';
 import {
   CONTRACT_EXECUTABLE_TYPE,
   NETWORK,
@@ -510,7 +510,9 @@ export class StellarService implements IContractService {
     }
   }
 
-  async getContractSpecEntries(instanceValue: xdr.ContractExecutable) {
+  async getContractSpecEntries(
+    instanceValue: xdr.ContractExecutable,
+  ): Promise<any[]> {
     try {
       const contractCode = await this.getWasmCode(instanceValue);
       const wasmModule = new WebAssembly.Module(contractCode);
@@ -525,7 +527,7 @@ export class StellarService implements IContractService {
     }
   }
 
-  async getContractEvents(contractId: string): Promise<EventResponse[]> {
+  async getContractEvents(contractId: string): Promise<EncodeEvent[]> {
     const oneDayEarlierLedger = 9999;
     const { sequence } = await this.server.getLatestLedger();
     const newStartLedger = sequence - oneDayEarlierLedger;

--- a/src/common/application/types/contract-events.ts
+++ b/src/common/application/types/contract-events.ts
@@ -8,8 +8,14 @@ interface BaseEventResponse {
   pagingToken: string;
   inSuccessfulContractCall: boolean;
 }
-export interface EventResponse extends BaseEventResponse {
+export interface EncodeEvent extends BaseEventResponse {
   contractId?: Contract;
   topic: xdr.ScVal[];
   value: xdr.ScVal;
+}
+
+export interface EventResponse extends BaseEventResponse {
+  contractId: string;
+  topic: any[];
+  value: any;
 }

--- a/src/common/application/types/soroban.enum.ts
+++ b/src/common/application/types/soroban.enum.ts
@@ -9,3 +9,29 @@ export enum SOROBAN_SERVER {
   TESTNET = 'https://soroban-testnet.stellar.org',
   MAINNET = 'https://soroban-rpc.mainnet.stellar.gateway.fm',
 }
+
+export enum CONTRACT_EXECUTABLE_TYPE {
+  STELLAR_ASSET = 'contractExecutableStellarAsset',
+  WASM = 'contractExecutableWasm',
+}
+
+export enum SC_VAL_TYPE {
+  BOOL = 'scvBool',
+  ERROR = 'scvError',
+  U32 = 'scvU32',
+  I32 = 'scvI32',
+  U64 = 'scvU64',
+  I64 = 'scvI64',
+  TIMEPOINT = 'scvTimepoint',
+  DURATION = 'scvDuration',
+  U128 = 'scvU128',
+  I128 = 'scvI128',
+  U256 = 'scvU256',
+  I256 = 'scvI256',
+  BYTES = 'scvBytes',
+  STRING = 'scvString',
+  SYMBOL = 'scvSymbol',
+  ADDRESS = 'scvAddress',
+  VEC = 'scvVec',
+  MAP = 'scvMap',
+}

--- a/src/common/common.module.ts
+++ b/src/common/common.module.ts
@@ -2,6 +2,7 @@ import { Module, forwardRef } from '@nestjs/common';
 
 import { MethodModule } from '@/modules/method/method.module';
 
+import { StellarMapper } from './application/mapper/contract.mapper';
 import { CONTRACT_SERVICE } from './application/repository/contract.interface.service';
 import { StellarService } from './application/service/stellar.service';
 
@@ -12,6 +13,7 @@ import { StellarService } from './application/service/stellar.service';
       provide: CONTRACT_SERVICE,
       useClass: StellarService,
     },
+    StellarMapper,
   ],
   exports: [
     {


### PR DESCRIPTION
### Summary

- Added ability to load and run Stellar Asset Contracts in the application.
- Each contract (SAC or Smart Contract) has specific functions to bring in its functions or load parameters when creating transactions
- A mapper is created to be able to send the data in readable values to the front end.

### Details

- Add SAC in stellar.service
- Add StellarMapper for mapping Stellar data
