### PR TITLE
Feat: Fix error handling in runInvocation

### DIFF
--- a/src/common/application/mapper/contract.mapper.ts
+++ b/src/common/application/mapper/contract.mapper.ts
@@ -49,14 +49,16 @@ export class StellarMapper {
     });
   }
 
-  getScValFromStellarAssetContract(selectedMethod: Method): xdr.ScVal[] {
+  getScValFromStellarAssetContract(
+    selectedMethod: Partial<Method>,
+  ): xdr.ScVal[] {
     const params = this.getParamsFromStellarAssetContract(selectedMethod);
     return params.map((param) =>
       nativeToScVal(param.value, { type: param.type }),
     );
   }
 
-  getParamsFromStellarAssetContract(selectedMethod: Method): Param[] {
+  getParamsFromStellarAssetContract(selectedMethod: Partial<Method>): Param[] {
     return selectedMethod.params.map((param) => {
       return {
         value: param.value,
@@ -80,5 +82,10 @@ export class StellarMapper {
       default:
         return value.value();
     }
+  }
+
+  fromTxFailedResponseToDisplayResponse(resultXdr: string): string {
+    return xdr.TransactionResult.fromXDR(resultXdr, 'base64').result().switch()
+      .name;
   }
 }

--- a/src/common/application/types/soroban.enum.ts
+++ b/src/common/application/types/soroban.enum.ts
@@ -2,12 +2,15 @@ export enum NETWORK {
   SOROBAN_FUTURENET = 'FUTURENET',
   SOROBAN_TESTNET = 'TESTNET',
   SOROBAN_MAINNET = 'MAINNET',
+  SOROBAN_LOCAL = 'LOCAL',
+  SOROBAN_LOCAL_PASSPHRASE = 'Standalone Network ; February 2017',
 }
 
 export enum SOROBAN_SERVER {
   FUTURENET = 'https://rpc-futurenet.stellar.org',
   TESTNET = 'https://soroban-testnet.stellar.org',
   MAINNET = 'https://soroban-rpc.mainnet.stellar.gateway.fm',
+  LOCAL = 'http://localhost:8000/',
 }
 
 export enum CONTRACT_EXECUTABLE_TYPE {
@@ -34,4 +37,8 @@ export enum SC_VAL_TYPE {
   ADDRESS = 'scvAddress',
   VEC = 'scvVec',
   MAP = 'scvMap',
+}
+
+export enum SOROBAN_CONTRACT_ERROR {
+  HOST_FAILED = 'host invocation failed',
 }

--- a/src/modules/method/application/mapper/method.mapper.ts
+++ b/src/modules/method/application/mapper/method.mapper.ts
@@ -3,7 +3,7 @@ import { MethodResponseDto } from '../dto/method-response.dto';
 import { IMethodValues, IUpdateMethodValues } from '../service/method.service';
 
 export class MethodMapper {
-  fromDtoToEntity(createMethodDto: IMethodValues): Method {
+  fromDtoToEntity(createMethodDto: IMethodValues | Partial<Method>): Method {
     const { name, inputs, outputs, invocationId, params, docs } =
       createMethodDto;
     return new Method(name, inputs, outputs, params, docs, invocationId);


### PR DESCRIPTION
### Summary

- Added error handling when operations within transactions fail due to contract errors.
- Hashes on failed transactions are decoded.
- Mapped errors by Soroban `#contracterror`


### Details

- Added mapper for `contracterror` in runInvocation catch.
- Hashes of failed transactions are decoded.
- Fixed type of `selectedMethod`
