### PR TITLE
Feat: Add run invocation error handler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@nestjs/platform-express": "^9.0.0",
         "@nestjs/swagger": "^7.1.14",
         "@nestjs/typeorm": "^10.0.0",
+        "@stellar/stellar-sdk": "^11.3.0",
         "amazon-cognito-identity-js": "^6.3.6",
         "better-sqlite3": "^7.6.2",
         "class-transformer": "^0.5.1",
@@ -30,7 +31,6 @@
         "rimraf": "^3.0.2",
         "rxjs": "^7.2.0",
         "sqlite3": "^5.1.4",
-        "stellar-sdk": "^11.1.0",
         "typeorm": "^0.3.17",
         "typeorm-naming-strategies": "^4.1.0"
       },
@@ -2402,16 +2402,30 @@
       "integrity": "sha512-Uy0+khmZqUrUGm5dmMqVlnvufZRSK0FbYzVgp0UMstm+F5+W2/jnEEQyc9vo1ZR/E5ZI/B1WjjoTqBqwJL6Krw=="
     },
     "node_modules/@stellar/js-xdr": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@stellar/js-xdr/-/js-xdr-3.0.1.tgz",
-      "integrity": "sha512-dp5Eh7Nr1YjiIeqpdkj2cQYxfoPudDAH3ck8MWggp48Htw66Z/hUssNYUQG/OftLjEmHT90Z/dtey2Y77DOxIw=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@stellar/js-xdr/-/js-xdr-3.1.1.tgz",
+      "integrity": "sha512-3gnPjAz78htgqsNEDkEsKHKosV2BF2iZkoHCNxpmZwUxiPsw+2VaXMed8RRMe0rGk3d5GZe7RrSba8zV80J3Ag=="
     },
-    "node_modules/@stellar/stellar-base": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-10.0.1.tgz",
-      "integrity": "sha512-BDbx7VHOEQh+4J3Q+gStNXgPaNckVFmD4aOlBBGwxlF6vPFmVnW8IoJdkX7T58zpX55eWI6DXvEhDBlrqTlhAQ==",
+    "node_modules/@stellar/stellar-sdk": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-11.3.0.tgz",
+      "integrity": "sha512-i+heopibJNRA7iM8rEPz0AXphBPYvy2HDo8rxbDwWpozwCfw8kglP9cLkkhgJe8YicgLrdExz/iQZaLpqLC+6w==",
       "dependencies": {
-        "@stellar/js-xdr": "^3.0.1",
+        "@stellar/stellar-base": "^11.0.1",
+        "axios": "^1.6.8",
+        "bignumber.js": "^9.1.2",
+        "eventsource": "^2.0.2",
+        "randombytes": "^2.1.0",
+        "toml": "^3.0.0",
+        "urijs": "^1.19.1"
+      }
+    },
+    "node_modules/@stellar/stellar-sdk/node_modules/@stellar/stellar-base": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-11.0.1.tgz",
+      "integrity": "sha512-VQh+1KEtFjegD6spx08+lENt8tQOkQQQZoLtqExjpRXyWlqDhEe+bXMlBTYKDc5MIynHyD42RPEib27UG17trA==",
+      "dependencies": {
+        "@stellar/js-xdr": "^3.1.1",
         "base32.js": "^0.1.0",
         "bignumber.js": "^9.1.2",
         "buffer": "^6.0.3",
@@ -2419,10 +2433,10 @@
         "tweetnacl": "^1.0.3"
       },
       "optionalDependencies": {
-        "sodium-native": "^4.0.1"
+        "sodium-native": "^4.0.10"
       }
     },
-    "node_modules/@stellar/stellar-base/node_modules/buffer": {
+    "node_modules/@stellar/stellar-sdk/node_modules/buffer": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
       "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
@@ -3467,11 +3481,11 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
-      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
+      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
       "dependencies": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
@@ -6704,9 +6718,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "funding": [
         {
           "type": "individual",
@@ -9768,9 +9782,9 @@
       }
     },
     "node_modules/node-gyp-build": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.7.1.tgz",
-      "integrity": "sha512-wTSrZ+8lsRRa3I3H8Xr65dLWSgCvY2l4AOnaeKdPA9TB/WYMPaTcrzf3rXvFoVvjKNVnu0CcWSx54qq9GKRUYg==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.0.tgz",
+      "integrity": "sha512-u6fs2AEUljNho3EYTJNBfImO5QTo/J/1Etd+NVdCj7qWKUSN/bSLkZwhDv7I+w/MSC6qJ4cknepkAYykDdK8og==",
       "optional": true,
       "bin": {
         "node-gyp-build": "bin.js",
@@ -11345,13 +11359,13 @@
       }
     },
     "node_modules/sodium-native": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-4.0.4.tgz",
-      "integrity": "sha512-faqOKw4WQKK7r/ybn6Lqo1F9+L5T6NlBJJYvpxbZPetpWylUVqz449mvlwIBKBqxEHbWakWuOlUt8J3Qpc4sWw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-4.1.1.tgz",
+      "integrity": "sha512-LXkAfRd4FHtkQS4X6g+nRcVaN7mWVNepV06phIsC6+IZFvGh1voW5TNQiQp2twVaMf05gZqQjuS+uWLM6gHhNQ==",
       "hasInstallScript": true,
       "optional": true,
       "dependencies": {
-        "node-gyp-build": "^4.6.0"
+        "node-gyp-build": "^4.8.0"
       }
     },
     "node_modules/sonarqube-scanner": {
@@ -11493,20 +11507,6 @@
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/stellar-sdk": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/stellar-sdk/-/stellar-sdk-11.1.0.tgz",
-      "integrity": "sha512-fIdo77ogpU+ecHgs59pk9velpXd4F/ch0DzOI4QZw8zVZApc3oeNWP3+X6ui7BWpeRHAGsP2CHQzBLxm0JTIgg==",
-      "dependencies": {
-        "@stellar/stellar-base": "10.0.1",
-        "axios": "^1.6.0",
-        "bignumber.js": "^9.1.2",
-        "eventsource": "^2.0.2",
-        "randombytes": "^2.1.0",
-        "toml": "^3.0.0",
-        "urijs": "^1.19.1"
       }
     },
     "node_modules/streamsearch": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@nestjs/platform-express": "^9.0.0",
     "@nestjs/swagger": "^7.1.14",
     "@nestjs/typeorm": "^10.0.0",
+    "@stellar/stellar-sdk": "^11.3.0",
     "amazon-cognito-identity-js": "^6.3.6",
     "better-sqlite3": "^7.6.2",
     "class-transformer": "^0.5.1",
@@ -61,7 +62,6 @@
     "rimraf": "^3.0.2",
     "rxjs": "^7.2.0",
     "sqlite3": "^5.1.4",
-    "stellar-sdk": "^11.1.0",
     "typeorm": "^0.3.17",
     "typeorm-naming-strategies": "^4.1.0"
   },

--- a/src/common/application/adapter/stellar.adapter.interface.ts
+++ b/src/common/application/adapter/stellar.adapter.interface.ts
@@ -1,4 +1,4 @@
-import { ContractSpec, Transaction, xdr } from 'stellar-sdk';
+import { ContractSpec, Transaction, xdr } from '@stellar/stellar-sdk';
 
 import {
   EncodeEvent,

--- a/src/common/application/mapper/contract.mapper.ts
+++ b/src/common/application/mapper/contract.mapper.ts
@@ -1,14 +1,19 @@
-import { nativeToScVal, scValToNative, xdr } from 'stellar-sdk';
+import { nativeToScVal, scValToNative, xdr } from '@stellar/stellar-sdk';
 
 import { Method } from '@/modules/method/domain/method.domain';
 
-import { EncodeEvent, EventResponse } from '../types/soroban';
-import { SC_VAL_TYPE } from '../types/soroban.enum';
+import {
+  ContractErrorResponse,
+  EncodeEvent,
+  EventResponse,
+  Param,
+} from '../types/soroban';
+import {
+  SC_VAL_TYPE,
+  SOROBAN_CONTRACT_ERROR,
+  SendTransactionStatus,
+} from '../types/soroban.enum';
 
-type Param = {
-  value: string;
-  type: any;
-};
 export class StellarMapper {
   SCSpecTypeMap = {
     SC_SPEC_TYPE_BOOL: 'b',
@@ -82,5 +87,29 @@ export class StellarMapper {
       default:
         return value.value();
     }
+  }
+
+  fromTxResultToDisplayResponse(resultXdr: string): string {
+    return xdr.TransactionResult.fromXDR(resultXdr, 'base64').result().switch()
+      .name;
+  }
+
+  fromContractErrorToDisplayResponse(error: string): ContractErrorResponse {
+    const regex = /Caused by:(.*?)(?=Backtrace|$)/s;
+    const match = error.match(regex);
+
+    if (match) {
+      return {
+        status: SendTransactionStatus.ERROR,
+        title: SOROBAN_CONTRACT_ERROR.HOST_FAILED,
+        response: match[0],
+      };
+    }
+
+    return {
+      status: SendTransactionStatus.ERROR,
+      title: SOROBAN_CONTRACT_ERROR.HOST_FAILED,
+      response: error,
+    };
   }
 }

--- a/src/common/application/mapper/contract.mapper.ts
+++ b/src/common/application/mapper/contract.mapper.ts
@@ -95,6 +95,7 @@ export class StellarMapper {
   }
 
   fromContractErrorToDisplayResponse(error: string): ContractErrorResponse {
+    // This regex separates the cause and the event of the error
     const regex = /Caused by:(.*?)(?=Backtrace|$)/s;
     const match = error.match(regex);
 

--- a/src/common/application/repository/contract.interface.service.ts
+++ b/src/common/application/repository/contract.interface.service.ts
@@ -1,8 +1,9 @@
-import { xdr } from 'stellar-sdk';
+import { xdr } from '@stellar/stellar-sdk';
 
 import { Method } from '@/modules/method/domain/method.domain';
 
 import { IGeneratedMethod } from '../service/stellar.service';
+import { ContractErrorResponse, RunInvocationResponse } from '../types/soroban';
 
 export interface IContractService {
   verifyNetwork(selectedNetwork: string): void;
@@ -28,7 +29,7 @@ export interface IContractService {
     secretKey: string,
     contractId: string,
     method: Partial<Method>,
-  );
+  ): Promise<RunInvocationResponse | ContractErrorResponse>;
 }
 
 export const CONTRACT_SERVICE = 'CONTRACT_SERVICE';

--- a/src/common/application/service/__test__/stellar.service.mocks.ts
+++ b/src/common/application/service/__test__/stellar.service.mocks.ts
@@ -1,0 +1,53 @@
+import { xdr } from '@stellar/stellar-sdk';
+
+import {
+  GetTransactionStatus,
+  SendTransactionStatus,
+} from '../../types/soroban.enum';
+
+export const contractExecutable: xdr.ContractExecutable = {
+  switch: jest.fn(),
+  wasmHash: jest.fn(),
+  value: jest.fn(),
+  toXDR: jest.fn(),
+};
+
+export const getTxFailed = {
+  status: GetTransactionStatus.FAILED,
+  ledger: 0,
+  createdAt: 0,
+  applicationOrder: 0,
+  feeBump: false,
+  envelopeXdr: undefined,
+  resultXdr: undefined,
+  resultMetaXdr: undefined,
+  latestLedger: 0,
+  latestLedgerCloseTime: 0,
+  oldestLedger: 0,
+  oldestLedgerCloseTime: 0,
+};
+
+export const rawGetTxFailed = {
+  status: GetTransactionStatus.FAILED,
+  resultXdr: '',
+  latestLedger: 0,
+  latestLedgerCloseTime: 0,
+  oldestLedger: 0,
+  oldestLedgerCloseTime: 0,
+};
+
+export const rawSendTxPending = {
+  status: SendTransactionStatus.PENDING,
+  errorResultXdr: '',
+  hash: '',
+  latestLedger: 0,
+  latestLedgerCloseTime: 0,
+};
+
+export const rawSendTxError = {
+  status: SendTransactionStatus.ERROR,
+  errorResultXdr: '',
+  hash: '',
+  latestLedger: 0,
+  latestLedgerCloseTime: 0,
+};

--- a/src/common/application/types/soroban.d.ts
+++ b/src/common/application/types/soroban.d.ts
@@ -1,12 +1,13 @@
 import {
   Contract,
+  EventType,
   Memo,
   MemoType,
   Operation,
   SorobanRpc,
   Transaction as Tx,
   xdr,
-} from 'stellar-sdk';
+} from '@stellar/stellar-sdk';
 
 export type Transaction = Tx<Memo<MemoType>, Operation[]>;
 
@@ -20,7 +21,7 @@ export type RawGetTransactionResponse =
 
 interface BaseEventResponse {
   id: string;
-  type: 'contract' | 'system' | 'diagnostic';
+  type: EventType;
   ledger: number;
   ledgerClosedAt: string;
   pagingToken: string;
@@ -37,7 +38,14 @@ export interface EventResponse extends BaseEventResponse {
   topic: any[];
   value: any;
 }
-export interface SorobanContractErrorResponse {
+
+export interface RunInvocationResponse {
+  status: string;
+  response: string | number;
+  method: Method;
+  events?: EventResponse[];
+}
+export interface ContractErrorResponse {
   status: string;
   title: string;
   response: string;

--- a/src/common/application/types/soroban.enum.ts
+++ b/src/common/application/types/soroban.enum.ts
@@ -35,3 +35,19 @@ export enum SC_VAL_TYPE {
   VEC = 'scvVec',
   MAP = 'scvMap',
 }
+
+export enum SOROBAN_CONTRACT_ERROR {
+  HOST_FAILED = 'host invocation failed',
+  HOST_ERROR = 'HostError',
+}
+
+export enum GetTransactionStatus {
+  SUCCESS = 'SUCCESS',
+  NOT_FOUND = 'NOT_FOUND',
+  FAILED = 'FAILED',
+}
+
+export enum SendTransactionStatus {
+  ERROR = 'ERROR',
+  PENDING = 'PENDING',
+}

--- a/src/common/infrastructure/stellar/stellar.adapter.ts
+++ b/src/common/infrastructure/stellar/stellar.adapter.ts
@@ -9,7 +9,7 @@ import {
   SorobanRpc,
   TransactionBuilder,
   xdr,
-} from 'stellar-sdk';
+} from '@stellar/stellar-sdk';
 
 import { IStellarAdapter } from '@/common/application/adapter/stellar.adapter.interface';
 import {
@@ -118,22 +118,18 @@ export class StellarAdapter implements IStellarAdapter {
     methodName: string,
     scArgs: xdr.ScVal[],
   ): Promise<Transaction> {
-    try {
-      const account = await this.server.getAccount(publicKey);
-      const contract = new Contract(contractId);
+    const account = await this.server.getAccount(publicKey);
+    const contract = new Contract(contractId);
 
-      const transaction = new TransactionBuilder(account, {
-        fee: BASE_FEE,
-        networkPassphrase: this.networkPassphrase,
-      })
-        .addOperation(contract.call(methodName, ...scArgs))
-        .setTimeout(60)
-        .build();
+    const transaction = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: this.networkPassphrase,
+    })
+      .addOperation(contract.call(methodName, ...scArgs))
+      .setTimeout(60)
+      .build();
 
-      return await this.server.prepareTransaction(transaction);
-    } catch (error) {
-      return error;
-    }
+    return await this.server.prepareTransaction(transaction);
   }
 
   signTransaction(tx: Transaction, secretKey: string): void {


### PR DESCRIPTION
### Summary

- Error handling is added when running an invocation. Either by errors in the operation or in the transaction.
- Run invocations now handle 2 types of responses
      - In case there is an error in the transaction
      - In case there is a Soroban error in the operations.
- Stellar dependency is updated

### Details

- Add error handling when running invocation with `RunInvocationResponse` | `ContractErrorResponse`
- Add Soroban enums and types
- Update stellar dependency from `stellar-sdk` to `@stellar/stellar-sdk`
