### PR TITLE
Refactor: invocation transaction

### DIFF
--- a/src/common/application/repository/contract.interface.service.ts
+++ b/src/common/application/repository/contract.interface.service.ts
@@ -2,7 +2,10 @@ import { xdr } from '@stellar/stellar-sdk';
 
 import { Method } from '@/modules/method/domain/method.domain';
 
-import { IGeneratedMethod } from '../service/stellar.service';
+import {
+  IGeneratedMethod,
+  IRunInvocationParams,
+} from '../service/stellar.service';
 import { ContractErrorResponse, RunInvocationResponse } from '../types/soroban';
 
 export interface IContractService {
@@ -25,11 +28,13 @@ export interface IContractService {
     selectedMethod: Method,
   ): Promise<xdr.ScVal[]>;
   runInvocation(
-    publicKey: string,
-    secretKey: string,
-    contractId: string,
-    method: Partial<Method>,
+    runInvocationParams: IRunInvocationParams,
   ): Promise<RunInvocationResponse | ContractErrorResponse>;
+  getPreparedTransactionXDR(
+    contractId: string,
+    publicKey: string,
+    selectedMethod: Partial<Method>,
+  ): Promise<string>;
 }
 
 export const CONTRACT_SERVICE = 'CONTRACT_SERVICE';

--- a/src/common/application/service/__test__/stellar.service.spec.ts
+++ b/src/common/application/service/__test__/stellar.service.spec.ts
@@ -152,12 +152,12 @@ describe('StellarService', () => {
       stellarAdapter.changeNetwork(NETWORK.SOROBAN_TESTNET);
 
       const { publicKey, secretKey } = await getRandomKeypair();
-      const result = await service.runInvocation(
+      const result = await service.runInvocation({
+        contractId: contracts.smart,
+        selectedMethod: selectedMethod.smart,
         publicKey,
         secretKey,
-        contracts.smart,
-        selectedMethod.smart,
-      );
+      });
 
       expect(result.status).toEqual(GetTransactionStatus.SUCCESS);
     }, 45000);
@@ -166,12 +166,12 @@ describe('StellarService', () => {
       stellarAdapter.changeNetwork(NETWORK.SOROBAN_TESTNET);
 
       const { publicKey, secretKey } = await getRandomKeypair();
-      const result = await service.runInvocation(
+      const result = await service.runInvocation({
+        contractId: contracts.sac,
+        selectedMethod: selectedMethod.sac,
         publicKey,
         secretKey,
-        contracts.sac,
-        selectedMethod.sac,
-      );
+      });
 
       expect(result).toEqual(
         expect.objectContaining({
@@ -190,12 +190,12 @@ describe('StellarService', () => {
         .spyOn(stellarAdapter, 'rawSendTransaction')
         .mockResolvedValue(rawSendTxError);
 
-      const result = await service.runInvocation(
-        'publicKey',
-        'secretKey',
-        'contractId',
-        mockedMethod,
-      );
+      const result = await service.runInvocation({
+        contractId: 'contractId',
+        selectedMethod: mockedMethod,
+        publicKey: 'publicKey',
+        secretKey: 'secretKey',
+      });
 
       expect(stellarAdapter.rawSendTransaction).toHaveBeenCalled();
       expect(stellarMapper.fromTxResultToDisplayResponse).toHaveBeenCalled();
@@ -222,12 +222,12 @@ describe('StellarService', () => {
         .spyOn(stellarAdapter, 'rawGetTransaction')
         .mockResolvedValue(rawGetTxFailed);
 
-      const result = await service.runInvocation(
-        'publicKey',
-        'secretKey',
-        'contractId',
-        mockedMethod,
-      );
+      const result = await service.runInvocation({
+        contractId: 'contractId',
+        selectedMethod: mockedMethod,
+        publicKey: 'publicKey',
+        secretKey: 'secretKey',
+      });
 
       expect(stellarAdapter.rawSendTransaction).toHaveBeenCalled();
       expect(stellarAdapter.getTransaction).toHaveBeenCalled();
@@ -249,12 +249,12 @@ describe('StellarService', () => {
           'Caused by:\n    HostError: Error(Contract, #2)\n    \n',
         );
 
-      const result = await service.runInvocation(
-        'publicKey',
-        'secretKey',
-        'contractId',
-        mockedMethod,
-      );
+      const result = await service.runInvocation({
+        contractId: 'contractId',
+        selectedMethod: mockedMethod,
+        publicKey: 'publicKey',
+        secretKey: 'secretKey',
+      });
 
       expect(stellarAdapter.rawSendTransaction).toHaveBeenCalled();
       expect(result).toEqual(

--- a/src/common/application/service/stellar.service.ts
+++ b/src/common/application/service/stellar.service.ts
@@ -4,7 +4,15 @@ import {
   RequestTimeoutException,
   UseInterceptors,
 } from '@nestjs/common';
-import { xdr } from '@stellar/stellar-sdk';
+import {
+  Memo,
+  MemoType,
+  Networks,
+  Operation,
+  Transaction,
+  TransactionBuilder,
+  xdr,
+} from '@stellar/stellar-sdk';
 import { ResilienceInterceptor, RetryStrategy } from 'nestjs-resilience';
 
 import { StellarAdapter } from '@/common/infrastructure/stellar/stellar.adapter';
@@ -27,6 +35,14 @@ export interface IGeneratedMethod {
   docs: string | null;
   inputs: { name: string; type: string }[];
   outputs: { type: string }[];
+}
+
+export interface IRunInvocationParams {
+  contractId: string;
+  selectedMethod: Partial<Method>;
+  signedTransactionXDR?: string;
+  publicKey?: string;
+  secretKey?: string;
 }
 
 @Injectable()
@@ -551,24 +567,42 @@ export class StellarService implements IContractService {
     ),
   )
   async runInvocation(
-    publicKey: string,
-    secretKey: string,
-    contractId: string,
-    selectedMethod: Partial<Method>,
+    runInvocationParams: IRunInvocationParams,
   ): Promise<RunInvocationResponse | ContractErrorResponse> {
-    try {
-      const scArgs = await this.generateScArgsToFromContractId(
-        contractId,
-        selectedMethod,
-      );
+    const {
+      contractId,
+      publicKey,
+      secretKey,
+      selectedMethod,
+      signedTransactionXDR,
+    } = runInvocationParams;
 
-      const transaction = await this.stellarAdapter.prepareTransaction(
-        publicKey,
-        contractId,
-        selectedMethod.name,
-        scArgs,
-      );
-      this.stellarAdapter.signTransaction(transaction, secretKey);
+    try {
+      let transaction: Transaction<Memo<MemoType>, Operation[]>;
+
+      if (!signedTransactionXDR && secretKey) {
+        const scArgs = await this.generateScArgsToFromContractId(
+          contractId,
+          selectedMethod,
+        );
+
+        transaction = await this.stellarAdapter.prepareTransaction(
+          publicKey,
+          contractId,
+          selectedMethod.name,
+          scArgs,
+        );
+        this.stellarAdapter.signTransaction(transaction, secretKey);
+      }
+
+      if (signedTransactionXDR) {
+        const netWorkPassphrase = Networks[this.currentNetwork];
+
+        transaction = TransactionBuilder.fromXDR(
+          signedTransactionXDR,
+          netWorkPassphrase,
+        ) as Transaction;
+      }
 
       const response = await this.stellarAdapter.rawSendTransaction(
         transaction,
@@ -618,13 +652,37 @@ export class StellarService implements IContractService {
         method: methodMapped,
       };
     } catch (error) {
+      const errorMessage = typeof error === 'string' ? error : error.message;
+
       if (
-        error.includes(SOROBAN_CONTRACT_ERROR.HOST_FAILED) ||
-        error.includes(SOROBAN_CONTRACT_ERROR.HOST_ERROR)
+        errorMessage.includes(SOROBAN_CONTRACT_ERROR.HOST_FAILED) ||
+        errorMessage.includes(SOROBAN_CONTRACT_ERROR.HOST_ERROR)
       ) {
-        return this.stellarMapper.fromContractErrorToDisplayResponse(error);
+        return this.stellarMapper.fromContractErrorToDisplayResponse(
+          errorMessage,
+        );
       }
       return error;
     }
+  }
+
+  async getPreparedTransactionXDR(
+    contractId: string,
+    publicKey: string,
+    selectedMethod: Partial<Method>,
+  ): Promise<string> {
+    const scArgs = await this.generateScArgsToFromContractId(
+      contractId,
+      selectedMethod,
+    );
+
+    const transaction = await this.stellarAdapter.prepareTransaction(
+      publicKey,
+      contractId,
+      selectedMethod.name,
+      scArgs,
+    );
+
+    return transaction.toXDR();
   }
 }

--- a/src/common/application/types/soroban.enum.ts
+++ b/src/common/application/types/soroban.enum.ts
@@ -38,7 +38,7 @@ export enum SC_VAL_TYPE {
 }
 
 export enum SOROBAN_CONTRACT_ERROR {
-  NO_ENTRIES_FOUND = "No entries found for this contract address",
+  NO_ENTRIES_FOUND = 'No entries found for this contract address',
   HOST_FAILED = 'host invocation failed',
   HOST_ERROR = 'HostError',
 }

--- a/src/common/infrastructure/stellar/stellar.adapter.ts
+++ b/src/common/infrastructure/stellar/stellar.adapter.ts
@@ -1,4 +1,4 @@
-import { Injectable, BadRequestException } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import {
   Address,
   BASE_FEE,
@@ -24,7 +24,6 @@ import {
   SOROBAN_CONTRACT_ERROR,
   SOROBAN_SERVER,
 } from '@/common/application/types/soroban.enum';
-import { ENVIROMENT_RESPONSE } from '@/modules/enviroment/application/exceptions/enviroment-response.enum';
 
 @Injectable()
 export class StellarAdapter implements IStellarAdapter {
@@ -70,12 +69,13 @@ export class StellarAdapter implements IStellarAdapter {
           durability: xdr.ContractDataDurability.persistent(),
         }),
       );
+
       const response = await this.server.getLedgerEntries(instanceKey);
 
       if (response.entries.length === 0) {
         throw new BadRequestException(SOROBAN_CONTRACT_ERROR.NO_ENTRIES_FOUND);
       }
-      
+
       const dataEntry = response.entries[0].val
         .contractData()
         .val()

--- a/src/modules/invocation/interface/__test__/fixture/Invocation.yml
+++ b/src/modules/invocation/interface/__test__/fixture/Invocation.yml
@@ -93,3 +93,14 @@ items:
     preInvocation: 'const a = () => "a"; a();'
     postInvocation: 'const a = () => "a"; a();'
     selectedMethod: '@method4'
+
+  invocation12:
+    id: 'invocation12'
+    name: 'invocation11'
+    folder: '@folder0'
+    network: 'FUTURENET'
+    contractId: 'contractId'
+    publicKey: 'publicKey5'
+    preInvocation: 'const a = () => "a"; a();'
+    postInvocation: 'const a = () => "a"; a();'
+    selectedMethod: '@method4'

--- a/src/modules/invocation/interface/__test__/invocation.e2e.spec.ts
+++ b/src/modules/invocation/interface/__test__/invocation.e2e.spec.ts
@@ -437,11 +437,19 @@ describe('Invocation - [/invocation]', () => {
     });
   });
 
-  describe('Run all - [GET /invocation/run]', () => {
+  describe('Run all - [POST /invocation/run]', () => {
     it('should run correctly the invocation', async () => {
       const invocationId = 'invocation5';
       await request(app.getHttpServer())
-        .get(`/invocation/${invocationId}/run`)
+        .post(`/invocation/${invocationId}/run`)
+        .expect(HttpStatus.OK);
+    });
+
+    it('should run correctly the invocation with a signed xdr', async () => {
+      const invocationId = 'invocation12';
+      await request(app.getHttpServer())
+        .post(`/invocation/${invocationId}/run`)
+        .send({ signedTransactionXDR: 'xdr' })
         .expect(HttpStatus.OK);
     });
   });
@@ -466,10 +474,10 @@ describe('Invocation - [/invocation]', () => {
     });
   });
 
-  describe('Run one  - [GET /invocation/:id/run]', () => {
+  describe('Run one  - [POST /invocation/:id/run]', () => {
     it('should validate all required fields', async () => {
       const response = await request(app.getHttpServer())
-        .get('/invocation/invocation4/run')
+        .post('/invocation/invocation4/run')
         .expect(HttpStatus.BAD_REQUEST);
 
       expect(response.body.message).toEqual(
@@ -478,7 +486,7 @@ describe('Invocation - [/invocation]', () => {
     });
     it('should validate missing params', async () => {
       const response = await request(app.getHttpServer())
-        .get('/invocation/invocation4/run')
+        .post('/invocation/invocation4/run')
         .expect(HttpStatus.BAD_REQUEST);
 
       expect(response.body.message).toEqual(
@@ -843,15 +851,15 @@ describe('Invocation - [/invocation]', () => {
         expect(response.body).toEqual(responseExpected);
       });
     });
-    describe('Run one  - [GET /invocation/:id/run]', () => {
+    describe('Run one  - [POST /invocation/:id/run]', () => {
       it('should run correctly the invocation', async () => {
         await request(app.getHttpServer())
-          .get(`${validRoute}/invocation11/run`)
+          .post(`${validRoute}/invocation11/run`)
           .expect(HttpStatus.OK);
       });
       it('should validate all required fields', async () => {
         const response = await request(app.getHttpServer())
-          .get(`${validRoute}/invocation10/run`)
+          .post(`${validRoute}/invocation10/run`)
           .expect(HttpStatus.BAD_REQUEST);
 
         expect(response.body.message).toEqual(

--- a/src/modules/invocation/interface/invocation-team.controller.ts
+++ b/src/modules/invocation/interface/invocation-team.controller.ts
@@ -3,6 +3,7 @@ import {
   Controller,
   Delete,
   Get,
+  HttpCode,
   Param,
   Patch,
   Post,
@@ -38,9 +39,28 @@ export class InvocationTeamController {
     return this.invocationService.findOneByInvocationAndTeamIdToDto(id, teamId);
   }
 
-  @Get('/:id/run')
-  runInvocation(@Param('teamId') teamId: string, @Param('id') id: string) {
-    return this.invocationService.runInvocationByTeam(id, teamId);
+  @Get('/:id/prepare')
+  prepareInvocation(@Param('teamId') teamId: string, @Param('id') id: string) {
+    return this.invocationService.prepareInvocationByTeam(id, teamId);
+  }
+
+  @Post('/:id/run')
+  @HttpCode(200)
+  runInvocation(
+    @Param('teamId') teamId: string,
+    @Param('id') id: string,
+    @Body()
+    {
+      signedTransactionXDR,
+    }: {
+      signedTransactionXDR?: string;
+    },
+  ) {
+    return this.invocationService.runInvocationByTeam(
+      id,
+      teamId,
+      signedTransactionXDR,
+    );
   }
 
   @Get('/:id/methods')

--- a/src/modules/invocation/interface/invocation.controller.ts
+++ b/src/modules/invocation/interface/invocation.controller.ts
@@ -3,6 +3,7 @@ import {
   Controller,
   Delete,
   Get,
+  HttpCode,
   Param,
   Patch,
   Post,
@@ -42,9 +43,9 @@ export class InvocationUserController {
     );
   }
 
-  @Get('/:id/run')
-  runInvocation(@AuthUser() user: IUserResponse, @Param('id') id: string) {
-    return this.invocationService.runInvocationByUser(id, user.id);
+  @Get('/:id/prepare')
+  prepareInvocation(@AuthUser() user: IUserResponse, @Param('id') id: string) {
+    return this.invocationService.prepareInvocationByUser(id, user.id);
   }
 
   @Get(':id/methods')
@@ -70,5 +71,24 @@ export class InvocationUserController {
   @Delete('/:id')
   delete(@AuthUser() user: IUserResponse, @Param('id') id: string) {
     return this.invocationService.deleteByUser(id, user.id);
+  }
+
+  @Post('/:id/run')
+  @HttpCode(200)
+  runInvocation(
+    @AuthUser() user: IUserResponse,
+    @Param('id') id: string,
+    @Body()
+    {
+      signedTransactionXDR,
+    }: {
+      signedTransactionXDR?: string;
+    },
+  ) {
+    return this.invocationService.runInvocationByUser(
+      id,
+      user.id,
+      signedTransactionXDR,
+    );
   }
 }


### PR DESCRIPTION
### Summary
In this pull request the functionality to prepare transactions was added: When a user connected to a wallet wants to invoke a contract, he must first prepare it, i.e. ask the backend to send him an xdr so that he can sign it and then invoke it.

In case the user is not connected with a wallet but with public and private keys it will not be necessary to go through the process of preparing the transaction, he can invoke it directly.


### Details

Added new endpoints: 
* `GET /invocation/:id/prepare`: Gets an XDR to be signed on the front end
* `GET /team/:teamId/invocation/:id/prepare`: Gets an XDR to be signed on the front end

Modified endpoints:
*  `GET /invocation/:id/run`: was modfied to -> `POST /invocation/:id/run`
*  `GET /team/:teamId/invocation/:id/run`: was modfied to -> `POST /team/:teamId/invocation/:id/run`
