### PR TITLE
Fix/steam transactions by memo

### DIFF
--- a/src/common/common.module.ts
+++ b/src/common/common.module.ts
@@ -85,8 +85,9 @@ export class CommonModule implements OnModuleInit {
 
   onModuleInit() {
     try {
-      const publicKey = this.stellarAdapter.getPublicKeyForCurrentNetwork();
-      this.stellarAdapter.streamTransactionsByMemoId(publicKey);
+      this.stellarAdapter.streamTransactionsByMemoId(
+        process.env.PUBLIC_KEY_MAINNET,
+      );
     } catch (error) {
       this.responseService.error('Listener start failed with error:', error);
     }

--- a/src/common/stellar_service/adapter/stellar.adapter.ts
+++ b/src/common/stellar_service/adapter/stellar.adapter.ts
@@ -30,6 +30,7 @@ import {
   FILE_UPLOAD_SERVICE,
   IFileUploadService,
 } from '@/common/S3/interface/file_upload.s3.interface';
+import { ENVIRONMENT } from '@/common/base/enum/common.enum';
 import {
   IResponseService,
   RESPONSE_SERVICE,
@@ -479,23 +480,16 @@ export class StellarAdapter implements IStellarAdapter {
     return builder.build();
   }
 
-  public getPublicKeyForCurrentNetwork(): string {
-    const publicKeyMap: { [key: string]: string | undefined } = {
-      [NETWORK.SOROBAN_TESTNET]: process.env.PUBLIC_KEY_TESTNET,
-      [NETWORK.SOROBAN_FUTURENET]: process.env.PUBLIC_KEY_FUTURENET,
-      [NETWORK.SOROBAN_MAINNET]: process.env.PUBLIC_KEY_MAINNET,
-    };
-    const publicKey = publicKeyMap[this.currentNetwork];
-    if (!publicKey) {
-      throw new Error('Network not supported or public key not configured');
-    }
-    return publicKey;
-  }
   public async streamTransactionsByMemoId(
     publicKey: string,
     memoId?: string,
   ): Promise<void> {
     try {
+      await this.setNetwork(
+        process.env.NODE_ENV === ENVIRONMENT.PRODUCTION
+          ? NETWORK.SOROBAN_MAINNET
+          : NETWORK.SOROBAN_FUTURENET,
+      );
       this.stellarServer
         .transactions()
         .forAccount(publicKey)

--- a/src/configuration/configuration.validate.ts
+++ b/src/configuration/configuration.validate.ts
@@ -23,8 +23,6 @@ export const configurationValidate = Joi.object({
   AWS_ECS_SUBNETS: Joi.string().required(),
   AWS_ECS_SECURITY_GROUP_ID: Joi.string().required(),
   LAMBDA_ARN: Joi.string().required(),
-  PUBLIC_KEY_FUTURENET: Joi.string().required(),
-  PUBLIC_KEY_TESTNET: Joi.string().required(),
   PUBLIC_KEY_MAINNET: Joi.string().required(),
   SENTRY_DSN: Joi.string().required(),
   SENTRY_ENABLED: Joi.boolean().required(),


### PR DESCRIPTION
This pull request includes several changes to streamline the handling of network-specific public keys and improve the configuration validation in the `common` module. The most important changes include removing the `getPublicKeyForCurrentNetwork` method, updating the `streamTransactionsByMemoId` method, and modifying the configuration validation schema.

### Changes to streamline public key handling:

* [`src/common/common.module.ts`](diffhunk://#diff-2c56b7b7d06d0a23371797df67045c4afc6e2d20f3cdc5735f01703ccbc609eaL88-R90): Updated the `onModuleInit` method to use `process.env.PUBLIC_KEY_MAINNET` directly instead of calling `getPublicKeyForCurrentNetwork`.
* [`src/common/stellar_service/adapter/stellar.adapter.ts`](diffhunk://#diff-95f51d5f01a0661015749afb727b5ecc6db935cc18cf39036fb8c7b571b94145L482-R492): Removed the `getPublicKeyForCurrentNetwork` method and updated the `streamTransactionsByMemoId` method to set the network based on the environment.

### Changes to configuration validation:

* [`src/configuration/configuration.validate.ts`](diffhunk://#diff-3dfe66179329996e2459ebf375162da4ec224e20d798da2fdfd763387bda1fb1L26-L27): Removed `PUBLIC_KEY_FUTURENET` and `PUBLIC_KEY_TESTNET` from the validation schema, keeping only `PUBLIC_KEY_MAINNET`.

### Import updates:

* [`src/common/stellar_service/adapter/stellar.adapter.ts`](diffhunk://#diff-95f51d5f01a0661015749afb727b5ecc6db935cc18cf39036fb8c7b571b94145R33): Added an import for `ENVIRONMENT` from `common.enum`.