### PR TITLE
Improve/contract id extraction and ci permissions

### DIFF
--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -16,13 +16,17 @@
 # and provide permission before this can report data back to azure.
 # Read the official documentation here : https://learn.microsoft.com/en-us/azure/defender-for-cloud/quickstart-onboard-github
 
-name: "Microsoft Defender For Devops"
+name: 'Microsoft Defender For Devops'
+
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   push:
-    branches: [ "*" ]
+    branches: ['*']
   pull_request:
-    branches: [ "*" ]
+    branches: ['*']
   schedule:
     - cron: '30 20 * * 1'
 
@@ -32,16 +36,16 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: |
-          5.0.x
-          6.0.x
-    - name: Run Microsoft Security DevOps
-      uses: microsoft/security-devops-action@v1.6.0
-      id: msdo
-    - name: Upload results to Security tab
-      uses: github/codeql-action/upload-sarif@v3
-      with:
-        sarif_file: ${{ steps.msdo.outputs.sarifFile }}
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            5.0.x
+            6.0.x
+      - name: Run Microsoft Security DevOps
+        uses: microsoft/security-devops-action@08976cb623803b1b36d7112d4ff9f59eae704de0
+        id: msdo
+      - name: Upload results to Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: ${{ steps.msdo.outputs.sarifFile }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,9 @@
 name: CI Workflow
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   push:
     branches: ['main']
@@ -29,7 +33,7 @@ jobs:
           NODE_ENV: development
 
       - name: NPM or Yarn install with caching
-        uses: bahmutov/npm-install@v1.6.0
+        uses: bahmutov/npm-install@ec9e87262db2a1be2ca3ceb2d506c413a220542c
 
       - name: Build
         run: |

--- a/src/modules/invocation/application/service/invocation.service.ts
+++ b/src/modules/invocation/application/service/invocation.service.ts
@@ -85,8 +85,11 @@ export class InvocationService {
     try {
       const regex = /{{([^}]*)}}/g;
       let contractId = inputString;
-      let match: string[];
+      let match: RegExpExecArray | null;
       while ((match = regex.exec(inputString)) !== null) {
+        if (match.index === regex.lastIndex) {
+          regex.lastIndex++;
+        }
         contractId = contractId.replace(match[0], match[1].trim());
       }
       return contractId;

--- a/src/modules/invocation/application/service/invocation.service.ts
+++ b/src/modules/invocation/application/service/invocation.service.ts
@@ -84,9 +84,11 @@ export class InvocationService {
   getContractIdValue(inputString: string) {
     try {
       const regex = /{{([^}]*)}}/g;
-      const contractId = inputString.replace(regex, (_match, text) =>
-        text.trim(),
-      );
+      let contractId = inputString;
+      let match: string[];
+      while ((match = regex.exec(inputString)) !== null) {
+        contractId = contractId.replace(match[0], match[1].trim());
+      }
       return contractId;
     } catch (error) {
       this.handleError(error);

--- a/src/modules/invocation/application/service/invocation.service.ts
+++ b/src/modules/invocation/application/service/invocation.service.ts
@@ -81,15 +81,18 @@ export class InvocationService {
     this.responseService.setContext(InvocationService.name);
   }
 
-  getContractIdValue = (inputString: string): string => {
+  getContractIdValue(inputString: string) {
     try {
-      const regex = /{{(.*?)}}/g;
-      const contractId = inputString.replace(regex, (_match, text) => text);
+      const regex = /{{([^}]*)}}/g;
+      const contractId = inputString.replace(regex, (_match, text) =>
+        text.trim(),
+      );
       return contractId;
     } catch (error) {
       this.handleError(error);
+      return '';
     }
-  };
+  }
 
   async getContractAddress(invocation: Invocation, contractId: string) {
     try {


### PR DESCRIPTION
This pull request includes several changes to CI workflows and a minor update to the `InvocationService` class. The most important changes are grouped below by theme.

### CI Workflow Updates:

* [`.github/workflows/defender-for-devops.yml`](diffhunk://#diff-71b69d767f4e5c498496c11436abd5218311582fbf6470905dca7b40cddad17bL19-R29): Added `permissions` block to specify read and write permissions for `contents` and `pull-requests`, respectively. Also updated the branch pattern syntax and the version of the `microsoft/security-devops-action` to a specific commit hash. [[1]](diffhunk://#diff-71b69d767f4e5c498496c11436abd5218311582fbf6470905dca7b40cddad17bL19-R29) [[2]](diffhunk://#diff-71b69d767f4e5c498496c11436abd5218311582fbf6470905dca7b40cddad17bL42-R46)
* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R3-R6): Added `permissions` block to specify read and write permissions for `contents` and `pull-requests`, respectively. Updated the version of the `bahmutov/npm-install` action to a specific commit hash. [[1]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R3-R6) [[2]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L32-R36)

### Codebase Improvement:

* [`src/modules/invocation/application/service/invocation.service.ts`](diffhunk://#diff-7369523c8e916bf6ee9012c7145f30061a934899b2769b0715d6183730a66266L84-L92): Refactored the `getContractIdValue` method to use a more precise regex pattern and added error handling to return an empty string if an error occurs.