### PR TITLE
Adds exclusion for specific analysis path

### DIFF
--- a/.msdo.config.json
+++ b/.msdo.config.json
@@ -1,0 +1,9 @@
+{
+  "analysis": {
+    "exclusions": [
+      {
+        "path": "/data/docker/volumes/cognito/db/local_7cSMGZ6h.json"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This pull request includes a small change to the `.msdo.config.json` file. The change adds an exclusion for a specific path to the analysis configuration.

* [`.msdo.config.json`](diffhunk://#diff-4ac14280fd2de3bbc837c60d5b9dd5e3332ed3413a43bc0d380a4c5e5fc08ff9R1-R9): Added an exclusion for `/data/docker/volumes/cognito/db/local_7cSMGZ6h.json` to the analysis configuration.