### PR TITLE
Fix/return existing task

### DIFF
--- a/.msdo.config.json
+++ b/.msdo.config.json
@@ -1,0 +1,9 @@
+{
+  "analysis": {
+    "exclusions": [
+      {
+        "path": "/data/docker/volumes/cognito/db/local_7cSMGZ6h.json"
+      }
+    ]
+  }
+}

--- a/.msdo.config.json
+++ b/.msdo.config.json
@@ -1,9 +1,0 @@
-{
-  "analysis": {
-    "exclusions": [
-      {
-        "path": "/data/docker/volumes/cognito/db/local_7cSMGZ6h.json"
-      }
-    ]
-  }
-}

--- a/src/modules/ephemeralEnvironment/application/service/ephemeralEnvironment.service.ts
+++ b/src/modules/ephemeralEnvironment/application/service/ephemeralEnvironment.service.ts
@@ -272,32 +272,7 @@ export class EphemeralEnvironmentService
     const existingTask = await this.getClientTask(clientId);
 
     if (existingTask) {
-      const intervalMinutes = parseInt(
-        existingTask.overrides?.containerOverrides
-          ?.find((override) => override.name === 'stellar')
-          ?.environment?.find((envVar) => envVar.name === 'INTERVAL_MINUTES')
-          ?.value || '',
-        10,
-      );
-      const taskStatusResponse = await this.getTaskPublicIp(
-        existingTask.taskArn,
-      );
-      const publicIpAddress = taskStatusResponse.payload.publicIp;
-
-      return this.responseService.createResponse({
-        payload: {
-          executionInterval: intervalMinutes,
-          publicIp: publicIpAddress,
-          status: existingTask.lastStatus as DesiredStatus,
-          taskArn: existingTask.taskArn || '',
-          taskStartedAt: existingTask.startedAt,
-          taskStoppedAt: new Date(
-            existingTask.startedAt.getTime() + intervalMinutes * 60000,
-          ),
-        },
-        message: MessagesEphemeralEnvironment.TASK_ALREADY_RUNNING,
-        type: 'OK',
-      });
+      return await this.getTaskStatus(clientId);
     }
     const uuid = uuidv4().split('-')[0];
 


### PR DESCRIPTION
This pull request includes a significant change to the `EphemeralEnvironmentService` class in `ephemeralEnvironment.service.ts`. The update simplifies the logic for handling existing tasks by delegating the task status retrieval to a new method.

Simplification of existing task handling:

* [`src/modules/ephemeralEnvironment/application/service/ephemeralEnvironment.service.ts`](diffhunk://#diff-928a64e048ac15e71578d37aa805dba61d3bbef196e3fa970056af8e1e9b7b2eL275-R275): Replaced the detailed logic for checking the execution interval, public IP, and task status with a call to the new `getTaskStatus` method, which abstracts and simplifies the task status retrieval process.