### PR TITLE
Fix/add env terrascan skiprule

### DIFF
--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -44,6 +44,8 @@ jobs:
             6.0.x
       - name: Run Microsoft Security DevOps
         uses: microsoft/security-devops-action@08976cb623803b1b36d7112d4ff9f59eae704de0
+        env:
+          terrascan_SkipRules: 'CKV_SECRET_9'
         id: msdo
       - name: Upload results to Security tab
         uses: github/codeql-action/upload-sarif@v3

--- a/.msdo.config.json
+++ b/.msdo.config.json
@@ -1,0 +1,9 @@
+{
+  "analysis": {
+    "exclusions": [
+      {
+        "path": "/data/docker/volumes/cognito/db/local_7cSMGZ6h.json"
+      }
+    ]
+  }
+}

--- a/.msdo.config.json
+++ b/.msdo.config.json
@@ -1,9 +1,0 @@
-{
-  "analysis": {
-    "exclusions": [
-      {
-        "path": "/data/docker/volumes/cognito/db/local_7cSMGZ6h.json"
-      }
-    ]
-  }
-}


### PR DESCRIPTION
This pull request includes updates to the security analysis configuration and workflow. The most important changes involve adding an environment variable to skip specific rules during the security scan and excluding a particular path from the analysis.

Security analysis configuration updates:

* [`.github/workflows/defender-for-devops.yml`](diffhunk://#diff-71b69d767f4e5c498496c11436abd5218311582fbf6470905dca7b40cddad17bR47-R48): Added `terrascan_SkipRules` environment variable to skip rule `CKV_SECRET_9` during the Microsoft Security DevOps action.
* [`.msdo.config.json`](diffhunk://#diff-4ac14280fd2de3bbc837c60d5b9dd5e3332ed3413a43bc0d380a4c5e5fc08ff9R1-R9): Added a new configuration file to exclude the path `/data/docker/volumes/cognito/db/local_7cSMGZ6h.json` from the analysis.